### PR TITLE
Fix issues uncovered by the latest static analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /.phpstan.neon
 /.phpunit.result.cache
 /composer.lock
-/crc.phar
 /infection-log.txt
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
             "@phpunit",
             "@infection"
         ],
-        "check-deps": "wget -O crc.phar https://github.com/maglnet/ComposerRequireChecker/releases/latest/download/composer-require-checker.phar && php crc.phar check && rm crc.phar",
+        "check-deps": "composer-require-checker check",
         "cs-check": "php-cs-fixer fix --dry-run",
         "cs-fix": "php-cs-fixer fix",
         "infection": "infection -jmax",

--- a/src/Parser/Peekable.php
+++ b/src/Parser/Peekable.php
@@ -47,7 +47,10 @@ final class Peekable
     }
 
     /**
+     * Advances the underlying generator, so subsequent peeks return a different item.
+     *
      * @return T | null
+     * @phpstan-impure
      */
     public function next(): mixed
     {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -26,7 +26,7 @@ use function sprintf;
 
 /**
  * @phpstan-type Shape array{
- *     vars?: array<string, string | int | bool | array<string, mixed> | null>,
+ *     vars?: array<string, string | int | bool | array<array-key, mixed> | null>,
  *     parent?: mixed,
  * }
  * @api
@@ -218,7 +218,7 @@ final class Scope
     }
 
     /**
-     * @return string|int|bool|array<string, mixed>|null
+     * @return string|int|bool|array<array-key, mixed>|null
      */
     private static function printValue(mixed $var): string|int|bool|array|null
     {

--- a/src/Type.php
+++ b/src/Type.php
@@ -20,6 +20,7 @@ use function get_object_vars;
 use function gettype;
 use function implode;
 use function is_array;
+use function is_string;
 use function sprintf;
 
 /**
@@ -101,7 +102,7 @@ final class Type implements Stringable
             'integer' => self::int(),
             'boolean' => self::bool(),
             'double' => self::float(),
-            'object' => self::struct(array_map(self::fromValue(...), get_object_vars($value))),
+            'object' => self::struct(self::fieldsFromObject($value)),
             default => throw new InvalidArgumentException(sprintf('Unsupported type %s', gettype($value))),
         };
     }
@@ -132,6 +133,35 @@ final class Type implements Stringable
     private static function never(): self
     {
         return new self('never');
+    }
+
+    /**
+     * @return array<string, self>
+     */
+    private static function fieldsFromObject(object $value): array
+    {
+        return array_map(self::fromValue(...), self::stringKeys(get_object_vars($value)));
+    }
+
+    /**
+     * PHP normalizes numeric property names like "1" to integer array keys. Such names are not valid identifiers, so
+     * they can neither be declared in a struct type nor accessed in an expression. Drop them instead of pretending
+     * they are fields.
+     *
+     * @template T
+     * @param array<array-key, T> $items
+     * @return array<string, T>
+     */
+    private static function stringKeys(array $items): array
+    {
+        $stringKeyed = [];
+        foreach ($items as $key => $item) {
+            if (!is_string($key)) {
+                continue;
+            }
+            $stringKeyed[$key] = $item;
+        }
+        return $stringKeyed;
     }
 
     /**

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 use function fopen;
+use function json_decode;
 use function sprintf;
 
 final class TypeTest extends TestCase
@@ -115,6 +116,10 @@ final class TypeTest extends TestCase
                 public int $age = 42;
             },
             Type::struct(['name' => Type::string(), 'age' => Type::int()]),
+        ];
+        yield 'Numeric property names are not struct fields' => [
+            json_decode('{"1": "one", "name": "John Doe"}'),
+            Type::struct(['name' => Type::string()]),
         ];
     }
 


### PR DESCRIPTION
Makes `composer check` green again on the current PHPStan/Psalm/ComposerRequireChecker releases. Both errors PHPStan reported turned out to be real problems rather than analyzer noise.

## Summary

- **`Peekable::next()` was not declared impure** — PHPStan carried an earlier `peek()`'s null narrowing across it and called a nullsafe operator redundant; taking its advice would have introduced a null dereference.
- **`Type::fromValue()` leaked non-string field names into structs** — `get_object_vars()` keys are not necessarily strings, producing struct fields the language cannot express.
- **`check-deps` downloaded the latest CRC phar** — which since 4.21.0 requires PHP >= 8.4 and fataled the PHP 8.3 CI jobs before running any check.

## `Peekable::next()` was not declared impure

`next()` advances the underlying generator, but PHPStan assumed it was side effect free. It therefore carried the "not null" narrowing of an earlier `peek()` across the `next()` call and flagged the nullsafe operator in `parseParam()` as redundant:

> Using nullsafe property access on non-nullable type ParsedToken. Use -> instead.

Following that advice would have introduced a null dereference on trailing input such as `|foo`, because after `next()` the next `peek()` can legitimately return `null` at end of input. Declaring `next()` impure states a true fact about the method and makes the narrowing correctly invalidate.

## `Type::fromValue()` leaked non-string field names into structs

`fromValue()` built struct fields straight from `get_object_vars()`, whose keys are *not* necessarily strings. PHP normalizes numeric property names to integer array keys, so `json_decode('{"1": "a"}')` yields an int key, which then became a struct field:

```php
Type::fromValue(json_decode('{"1": "a", "foo": "b"}'));
// before: { 1: string, foo: string }
// after:  { foo: string }
```

Those names are not valid identifiers, so they can be neither declared in a struct type (`{ 1: string }` → *Expected field name, got 1*) nor accessed in an expression (`s.1` → *Expected function name, got 1*). They are therefore dropped instead of being passed off as fields. A PHP array cannot hold `"1"` as a string key at all, which means the documented `array<string, Type>` shape of `Type::$fields` was not merely imprecise, it was unsatisfiable — this change makes it true rather than relaxing it.

## Composer Require Checker ran against the wrong PHP version

`check-deps` downloaded the phar from `releases/latest`, a URL with no notion of which PHP version the job runs on. ComposerRequireChecker dropped PHP 8.3 support in 4.21.0 (4.21+ require `~8.4.0 || ~8.5.0`), so both PHP 8.3 jobs fataled on startup:

> Your Composer dependencies require a PHP version ">= 8.4.0". You are running 8.3.32.

`maglnet/composer-require-checker` is already a dev dependency, so the installed binary is used instead. Composer resolves it against the PHP version in use, so each job gets a compatible release automatically rather than whatever happens to be newest — no hand-pinned version to maintain. Verified across the matrix: 8.3 and 8.4 resolve 4.20.0, both `--prefer-lowest` jobs resolve 4.16.0, and all four run clean.

## Backward compatibility

No public type is widened. `Type::struct()` and the public readonly `Type::$fields` keep their exact `array<string, Type>` signature; the fix is at the boundary that violated it. `roave-backward-compatibility-check` against `0.2.x` reports no new findings (the single `[BC] SKIPPED: Unable to compile initializer in class Declarations` it prints also appears when comparing `0.2.x` against itself, so it is a pre-existing tool limitation).

The only behavior change is the edge case above: an object with numeric property names no longer contributes them as struct fields. Field access, `assert()`, and subtype checks are unaffected for anything the language can express.

`Scope::printValue()` and the `Shape` alias do widen to `array<array-key, mixed>`, since a debug dump should show a numerically-named property rather than hide it. Both are private/`@internal` and reachable from no public signature.

## Verification

`composer check` passes: composer-require-checker, PHP-CS-Fixer, Psalm, PHPStan (level max), 542 tests, and Infection at 100% MSI with no escaped mutants. CI is green on all 25 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)