### PR TITLE
Check an expression's operands where the node is built

### DIFF
--- a/src/And_.php
+++ b/src/And_.php
@@ -7,8 +7,6 @@ namespace Eventjet\Ausdruck;
 use Eventjet\Ausdruck\Parser\Span;
 use Override;
 
-use function get_debug_type;
-use function is_bool;
 use function sprintf;
 
 /**
@@ -26,17 +24,13 @@ final class And_ extends Expression
         return sprintf('%s && %s', $this->left, $this->right);
     }
 
+    /**
+     * Short-circuits: the right operand is only evaluated if the left one is true.
+     */
     #[Override]
     public function evaluate(Scope $scope): bool
     {
-        $left = $this->left->evaluate($scope);
-        $right = $this->right->evaluate($scope);
-        if (!is_bool($left) || !is_bool($right)) {
-            throw new EvaluationError(
-                sprintf('Expected boolean operands, got %s and %s', get_debug_type($left), get_debug_type($right)),
-            );
-        }
-        return $left && $right;
+        return Operand::bool($this->left->evaluate($scope)) && Operand::bool($this->right->evaluate($scope));
     }
 
     #[Override]

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -5,9 +5,27 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck;
 
 use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\TypeAnnotation;
+use Eventjet\Ausdruck\Parser\TypeError;
 use Eventjet\Ausdruck\Parser\TypeHint;
 
+use function count;
+use function sprintf;
+
 /**
+ * The only place expression nodes are constructed, and therefore the only place their types are checked. Both the parser
+ * and the builder API on {@see Expression} go through here, so an expression that exists is an expression whose operands
+ * type-check and whose type is the one its operands give it. Anything that reads a value from a {@see Scope}
+ * ({@see Get}, {@see Call}) asserts that value against its declared type, so the guarantee survives evaluation too.
+ *
+ * The nodes therefore don't re-check their operands when they evaluate. They only narrow the mixed they get back from
+ * their sub-expressions, via {@see Operand}, to the type PHP needs to apply the operator.
+ *
+ * The one node whose type doesn't follow from its operands is a {@see Call}: what a call returns is what its inline
+ * annotation says, or what the function's declaration says, and only a *declared* function has a signature to check the
+ * receiver and the arguments against. {@see self::call()} therefore takes both, and resolves the return type from them
+ * rather than being handed one; null means there is nothing to check against, not that the check was skipped.
+ *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
@@ -22,6 +40,16 @@ final class Expr
 
     public static function eq(Expression $left, Expression $right): Eq
     {
+        if (!$right->matchesType($left->getType())) {
+            throw TypeError::create(
+                sprintf(
+                    'The expressions of both sides of === must be of the same type. Left: %s, right: %s',
+                    $left->getType(),
+                    $right->getType(),
+                ),
+                $right->location(),
+            );
+        }
         return new Eq($left, $right);
     }
 
@@ -55,21 +83,43 @@ final class Expr
     }
 
     /**
+     * @param TypeAnnotation|null $returnType The return type the call site spells out, or null if it doesn't spell one
+     *     out. What the call evaluates to is resolved from this and the declaration; see {@see self::returnType()}.
      * @param list<Expression> $arguments
+     * @param Type|null $signature The declared type of the function, or null if it has no declaration. Only a
+     *     declaration says which receiver and arguments a function accepts, so a call to an undeclared function has
+     *     nothing to check its operands against. That's the case for functions that are used with nothing but an
+     *     inline return type, and for every call built through {@see Expression::call()}, which has no declarations to
+     *     consult.
+     * @param Span|null $nameLocation Where the function is named, which is what an error about the function itself
+     *     rather than about one of its operands points at.
      */
-    public static function call(Expression $target, string $name, Type $type, array $arguments, Span|null $location = null): Call
-    {
-        return new Call($target, $name, $type, $arguments, $location ?? self::dummySpan());
+    public static function call(
+        Expression $target,
+        string $name,
+        TypeAnnotation|null $returnType,
+        array $arguments,
+        Type|null $signature,
+        Span|null $nameLocation = null,
+        Span|null $location = null,
+    ): Call {
+        $location ??= self::dummySpan();
+        $type = self::returnType($name, $returnType, $signature, $nameLocation ?? self::dummySpan());
+        if ($signature !== null) {
+            self::checkReceiver($target, $name, $signature);
+            self::checkArguments($arguments, $name, $signature, $location);
+        }
+        return new Call($target, $name, $type, $arguments, $location);
     }
 
     public static function or_(Expression $left, Expression $right): Or_
     {
-        return new Or_($left, $right);
+        return new Or_(self::assertBoolean($left, '||', 'left'), self::assertBoolean($right, '||', 'right'));
     }
 
     public static function and_(Expression $left, Expression $right): And_
     {
-        return new And_($left, $right);
+        return new And_(self::assertBoolean($left, '&&', 'left'), self::assertBoolean($right, '&&', 'right'));
     }
 
     /**
@@ -84,27 +134,214 @@ final class Expr
 
     public static function subtract(Expression $minuend, Expression $subtrahend): Subtract
     {
+        // Which operand is at fault doesn't change how we name the mistake, only which one we point at.
+        self::assertSameNumberType($minuend, $subtrahend, static fn(): string => sprintf(
+            'Can\'t subtract %s from %s',
+            $subtrahend->getType(),
+            $minuend->getType(),
+        ));
         return new Subtract($minuend, $subtrahend);
     }
 
     public static function gt(Expression $left, Expression $right): Gt
     {
+        self::assertSameNumberType($left, $right, static fn(Expression $bad, Expression $good): string => sprintf(
+            'Can\'t compare %s to %s',
+            $bad->getType(),
+            $good->getType(),
+        ));
         return new Gt($left, $right);
     }
 
-    public static function negative(Expression $expression, Span|null $location = null): Negative
+    /**
+     * Negating a number literal folds into a negative literal, so that -69 is the literal -69 rather than a negation of
+     * 69. The tokenizer deliberately doesn't fold the sign in, because there it couldn't tell the negative literal in
+     * `[-2]` apart from the subtraction in `a -2`; by the time we get here, the minus is known to be a negation.
+     *
+     * A Negative therefore never wraps a Literal, and isNumeric() has already established that one that gets this far
+     * holds an int or a float.
+     */
+    public static function negative(Expression $expression, Span|null $location = null): Negative|Literal
     {
-        return new Negative($expression, $location ?? self::dummySpan());
+        if (!self::isNumeric($expression)) {
+            throw TypeError::create(
+                sprintf('Can\'t negate %s', $expression->getType()),
+                $expression->location(),
+            );
+        }
+        $location ??= self::dummySpan();
+        return $expression instanceof Literal
+            ? new Literal(-Operand::number($expression->value()), $location)
+            : new Negative($expression, $location);
     }
 
     public static function fieldAccess(Expression $struct, string $field, Span $location): FieldAccess
     {
-        return new FieldAccess($struct, $field, $location);
+        $structType = $struct->getType();
+        if (!$structType->isStruct()) {
+            throw TypeError::create(
+                sprintf('Can\'t access field "%s" on non-struct type %s', $field, $structType),
+                $location,
+            );
+        }
+        $fieldType = $structType->getFieldType($field);
+        if ($fieldType === null) {
+            throw TypeError::create(sprintf('Unknown field "%s" on type %s', $field, $structType), $location);
+        }
+        return new FieldAccess($struct, $field, $fieldType, $location);
     }
 
-    private static function dummySpan(): Span
+    /**
+     * The location of an expression that has none, because it was built rather than parsed. It only ever fills a
+     * parameter list, or points an error at a source that isn't there.
+     */
+    public static function dummySpan(): Span
     {
         /** @infection-ignore-all These dummy spans are just there to fill parameter lists */
         return Span::char(1, 1);
+    }
+
+    /**
+     * int and float are the only types the arithmetic and ordering operators accept. Note that this has nothing to do
+     * with PHP's is_numeric(): a numeric string is a string.
+     */
+    private static function isNumeric(Expression $expr): bool
+    {
+        $type = $expr->getType();
+        return $type->equals(Type::int()) || $type->equals(Type::float());
+    }
+
+    /**
+     * The rule every arithmetic and ordering operator follows: both operands have to be numbers, and they have to be
+     * the same number type. The error points at whichever operand breaks it, so that operators that enforce the same
+     * rule can't drift into blaming different parts of the expression for the same mistake.
+     *
+     * @param callable(Expression, Expression): string $message Called with the offending operand first and the one it
+     *     was measured against second, for operators whose wording depends on which is which.
+     */
+    private static function assertSameNumberType(Expression $left, Expression $right, callable $message): void
+    {
+        if (!self::isNumeric($right)) {
+            throw TypeError::create($message($right, $left), $right->location());
+        }
+        if (!$left->matchesType($right->getType())) {
+            throw TypeError::create($message($left, $right), $left->location());
+        }
+    }
+
+    /**
+     * A call returns what its inline annotation says, and what the declaration says if it has no annotation. At least
+     * one of the two has to be there, and where both are, the annotation has to fit the declaration. Those are the same
+     * rules a variable's type follows; see {@see Parser\ExpressionParser::variable()}.
+     *
+     * Resolving the return type here rather than taking one is what keeps a Call's type and its signature from
+     * contradicting each other: there is no way to hand this a return type that the declaration disagrees with.
+     */
+    private static function returnType(
+        string $name,
+        TypeAnnotation|null $annotation,
+        Type|null $signature,
+        Span $nameLocation,
+    ): Type {
+        if ($annotation === null) {
+            return $signature?->returnType() ?? throw TypeError::create(
+                sprintf('Function %s is not declared and has no inline type', $name),
+                $nameLocation,
+            );
+        }
+        if ($signature !== null && !$annotation->type->isSubtypeOf($signature->returnType())) {
+            throw TypeError::create(
+                sprintf(
+                    'Inline return type %s of function %s does not match declared return type %s',
+                    $annotation->type,
+                    $name,
+                    $signature->returnType(),
+                ),
+                $annotation->location,
+            );
+        }
+        return $annotation->type;
+    }
+
+    /**
+     * A receiver function takes the expression it's called on as its first argument: `substr` is declared as
+     * func(string, [string, int, int]) and called as `foo:string.substr:string(0, 3)`, so `foo` has to be a string.
+     */
+    private static function checkReceiver(Expression $target, string $name, Type $signature): void
+    {
+        $receiverType = $signature->receiverType();
+        if ($receiverType === null) {
+            throw TypeError::create(
+                sprintf('%s can\'t be used as a receiver function because it doesn\'t accept any arguments', $name),
+                $target->location(),
+            );
+        }
+        if ($target->isSubtypeOf($receiverType)) {
+            return;
+        }
+        throw TypeError::create(
+            sprintf(
+                '%s must be called on an expression of type %s, but %s is of type %s',
+                $name,
+                $receiverType,
+                $target,
+                $target->getType(),
+            ),
+            $target->location(),
+        );
+    }
+
+    /**
+     * @param list<Expression> $arguments
+     * @param Span $location The location of the whole call, which is the best we can do to point at an argument that
+     *     isn't there.
+     */
+    private static function checkArguments(array $arguments, string $name, Type $signature, Span $location): void
+    {
+        $argumentTypes = $signature->argumentTypes();
+        if (count($arguments) !== count($argumentTypes)) {
+            // An argument too many is right there to point at. One that's missing isn't anywhere, so the call as a
+            // whole is the closest we can get.
+            $surplus = $arguments[count($argumentTypes)] ?? null;
+            throw TypeError::create(
+                sprintf('%s expects %d arguments, got %d', $name, count($argumentTypes), count($arguments)),
+                $surplus?->location() ?? $location,
+            );
+        }
+        foreach ($argumentTypes as $index => $argumentType) {
+            $argument = $arguments[$index];
+            if ($argument->isSubtypeOf($argumentType)) {
+                continue;
+            }
+            throw TypeError::create(
+                sprintf(
+                    'Argument %d of %s must be of type %s, got %s',
+                    $index + 1,
+                    $name,
+                    $argumentType,
+                    $argument->getType(),
+                ),
+                $argument->location(),
+            );
+        }
+    }
+
+    /**
+     * @param 'left' | 'right' $side
+     */
+    private static function assertBoolean(Expression $expr, string $operator, string $side): Expression
+    {
+        if ($expr->matchesType(Type::bool())) {
+            return $expr;
+        }
+        throw TypeError::create(
+            sprintf(
+                'The expression on the %s side of %s must be boolean, got %s',
+                $side,
+                $operator,
+                $expr->getType(),
+            ),
+            $expr->location(),
+        );
     }
 }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck;
 
 use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\TypeAnnotation;
 use Stringable;
 
 /**
@@ -38,11 +39,24 @@ abstract class Expression implements Stringable
     }
 
     /**
+     * Unlike the other builders, this one can't check its operands: there are no declarations here to look the
+     * function's signature up in, so there is nothing to check the receiver and the arguments against. The call is
+     * checked against $type when it's evaluated. Parse the expression instead of building it if you want the
+     * arguments checked up front.
+     *
+     * @param Type $type The function's return type. There's no declaration here to contradict, so it's taken as given.
      * @param list<Expression> $arguments
      */
     public function call(string $name, Type $type, array $arguments, Span|null $location = null): Call
     {
-        return Expr::call($this, $name, $type, $arguments, $location);
+        return Expr::call(
+            $this,
+            $name,
+            new TypeAnnotation($type, $location ?? Expr::dummySpan()),
+            $arguments,
+            signature: null,
+            location: $location,
+        );
     }
 
     public function matchesType(Type $type): bool

--- a/src/FieldAccess.php
+++ b/src/FieldAccess.php
@@ -7,8 +7,6 @@ namespace Eventjet\Ausdruck;
 use Eventjet\Ausdruck\Parser\Span;
 use Override;
 
-use function get_debug_type;
-use function is_object;
 use function property_exists;
 use function sprintf;
 
@@ -18,9 +16,14 @@ use function sprintf;
  */
 final class FieldAccess extends Expression
 {
+    /**
+     * @param Type $type The type {@see $field} is declared as on {@see $struct}. {@see Expr::fieldAccess()} resolves it,
+     *     which is also where we know the field exists at all.
+     */
     public function __construct(
         public readonly Expression $struct,
         public readonly string $field,
+        private readonly Type $type,
         private readonly Span $location,
     ) {
     }
@@ -39,11 +42,14 @@ final class FieldAccess extends Expression
     #[Override]
     public function evaluate(Scope $scope): mixed
     {
-        $struct = $this->struct->evaluate($scope);
-        if (!is_object($struct)) {
-            throw new EvaluationError(sprintf('Expected object, got %s', get_debug_type($struct)));
-        }
+        $struct = Operand::struct($this->struct->evaluate($scope));
         if (!property_exists($struct, $this->field)) {
+            /**
+             * Unreachable; see {@see Operand}. Kept because reading a missing property would quietly yield null rather
+             * than fail, which is the worst possible way for a bug in this library to surface.
+             *
+             * @infection-ignore-all
+             */
             throw new EvaluationError(sprintf('Unknown field "%s"', $this->field));
         }
         /** @phpstan-ignore-next-line property.dynamicName */
@@ -61,8 +67,6 @@ final class FieldAccess extends Expression
     #[Override]
     public function getType(): Type
     {
-        $structType = $this->struct->getType();
-        return $structType->getFieldType($this->field)
-            ?? throw new EvaluationError(sprintf('Unknown field "%s" on type %s', $this->field, $structType));
+        return $this->type;
     }
 }

--- a/src/Gt.php
+++ b/src/Gt.php
@@ -27,7 +27,7 @@ final class Gt extends Expression
     #[Override]
     public function evaluate(Scope $scope): bool
     {
-        return $this->left->evaluate($scope) > $this->right->evaluate($scope);
+        return Operand::number($this->left->evaluate($scope)) > Operand::number($this->right->evaluate($scope));
     }
 
     #[Override]

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -7,10 +7,11 @@ namespace Eventjet\Ausdruck;
 use Eventjet\Ausdruck\Parser\Span;
 use Override;
 
-use function is_float;
-use function is_int;
 use function sprintf;
 
+/**
+ * Never wraps a {@see Literal}: {@see Expr::negative()} folds a negated number literal into a negative one.
+ */
 final class Negative extends Expression
 {
     use LocationTrait;
@@ -28,11 +29,7 @@ final class Negative extends Expression
     #[Override]
     public function evaluate(Scope $scope): float|int
     {
-        $value = $this->expression->evaluate($scope);
-        if (!is_int($value) && !is_float($value)) {
-            throw new EvaluationError('Expected operand to be of type int or float');
-        }
-        return -$value;
+        return -Operand::number($this->expression->evaluate($scope));
     }
 
     #[Override]

--- a/src/Operand.php
+++ b/src/Operand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use function get_debug_type;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function sprintf;
+
+/**
+ * Narrows the mixed an expression hands back—from {@see Expression::evaluate()}, or from {@see Literal::value()}—to the
+ * concrete type an operator needs to apply its PHP counterpart.
+ *
+ * These are not type checks. {@see Expr} has already rejected operands of the wrong type, and everything that reads a
+ * value from a {@see Scope} ({@see Get}, {@see Call}) asserts it against its declared type, so none of these can fail
+ * for an expression that was built through {@see Expr}. They exist so the nodes can go from mixed to int, float, bool or
+ * object without a cast. Anything thrown here is a bug in this library, not in the expression that was evaluated.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Operand
+{
+    /**
+     * @psalm-suppress UnusedConstructor
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * @infection-ignore-all Unreachable; see the class docblock.
+     */
+    public static function bool(mixed $value): bool
+    {
+        return is_bool($value)
+            ? $value
+            : throw new EvaluationError(sprintf('Expected a boolean operand, got %s', get_debug_type($value)));
+    }
+
+    /**
+     * @infection-ignore-all Unreachable; see the class docblock.
+     */
+    public static function number(mixed $value): int|float
+    {
+        return is_int($value) || is_float($value)
+            ? $value
+            : throw new EvaluationError(sprintf('Expected an int or float operand, got %s', get_debug_type($value)));
+    }
+
+    /**
+     * @infection-ignore-all Unreachable; see the class docblock.
+     */
+    public static function struct(mixed $value): object
+    {
+        return is_object($value)
+            ? $value
+            : throw new EvaluationError(sprintf('Expected a struct operand, got %s', get_debug_type($value)));
+    }
+}

--- a/src/Or_.php
+++ b/src/Or_.php
@@ -7,8 +7,6 @@ namespace Eventjet\Ausdruck;
 use Eventjet\Ausdruck\Parser\Span;
 use Override;
 
-use function get_debug_type;
-use function is_bool;
 use function sprintf;
 
 /**
@@ -26,17 +24,13 @@ final class Or_ extends Expression
         return sprintf('%s || %s', $this->left, $this->right);
     }
 
+    /**
+     * Short-circuits: the right operand is only evaluated if the left one is false.
+     */
     #[Override]
     public function evaluate(Scope $scope): bool
     {
-        $left = $this->left->evaluate($scope);
-        $right = $this->right->evaluate($scope);
-        if (!is_bool($left) || !is_bool($right)) {
-            throw new EvaluationError(
-                sprintf('Expected boolean operands, got %s and %s', get_debug_type($left), get_debug_type($right)),
-            );
-        }
-        return $left || $right;
+        return Operand::bool($this->left->evaluate($scope)) || Operand::bool($this->right->evaluate($scope));
     }
 
     #[Override]

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -13,9 +13,7 @@ use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\StructLiteral;
 use Eventjet\Ausdruck\Type;
 
-use function array_shift;
 use function assert;
-use function count;
 use function in_array;
 use function is_string;
 use function sprintf;
@@ -55,36 +53,18 @@ final class ExpressionParser
     public static function parseTyped(string $expression, Type $type, Declarations|Types|null $types = null): Expression
     {
         $expr = self::parse($expression, $types);
-        return self::assertExpressionType($expr, $type, sprintf(
-            'Expected parsed expression to be of type %s, got %s',
-            $type,
-            $expr->getType(),
-        ));
-    }
-
-    private static function assertExpressionType(Expression $expr, Type $type, string $errorMessage): Expression
-    {
         if ($expr->matchesType($type)) {
             return $expr;
         }
-        throw TypeError::create($errorMessage, $expr->location());
+        throw TypeError::create(
+            sprintf('Expected parsed expression to be of type %s, got %s', $type, $expr->getType()),
+            $expr->location(),
+        );
     }
 
     private static function unexpectedToken(ParsedToken $token): never
     {
         throw SyntaxError::create(sprintf('Unexpected %s', Token::print($token->token)), $token->location());
-    }
-
-    private static function fieldAccess(Expression $target, string $name, Span $location): FieldAccess
-    {
-        $targetType = $target->getType();
-        if (!$targetType->isStruct()) {
-            throw TypeError::create(sprintf('Can\'t access field "%s" on non-struct type %s', $name, $targetType), $location);
-        }
-        if ($targetType->getFieldType($name) === null) {
-            throw TypeError::create(sprintf('Unknown field "%s" on type %s', $name, $targetType), $location);
-        }
-        return Expr::fieldAccess($target, $name, $location);
     }
 
     private function parseExpression(): Expression
@@ -176,30 +156,14 @@ final class ExpressionParser
             if ($left === null) {
                 self::unexpectedToken($parsedToken);
             }
-            $right = $this->parseExpressionUntilLogical();
-            $right = self::assertExpressionType($right, $left->getType(), sprintf(
-                'The expressions of both sides of === must be of the same type. Left: %s, right: %s',
-                $left->getType(),
-                $right->getType(),
-            ));
-            return $left->eq($right);
+            return $left->eq($this->parseExpressionUntilLogical());
         }
         if (in_array($token, [Token::Or, Token::And], true)) {
             $this->tokens->next();
             if ($left === null) {
                 self::unexpectedToken($parsedToken);
             }
-            $left = self::assertExpressionType($left, Type::bool(), sprintf(
-                'The expression on the left side of %s must be boolean, got %s',
-                Token::print($token),
-                $left->getType(),
-            ));
             $right = $this->parseExpression();
-            $right = self::assertExpressionType($right, Type::bool(), sprintf(
-                'The expression on the right side of %s must be boolean, got %s',
-                Token::print($token),
-                $right->getType(),
-            ));
             return $token === Token::Or ? $left->or_($right) : $left->and_($right);
         }
         if ($token === Token::Pipe) {
@@ -211,38 +175,16 @@ final class ExpressionParser
             if ($right === null) {
                 throw SyntaxError::create('Unexpected end of input', Span::char($parsedToken->line, $parsedToken->column + 1));
             }
-            if (!$right->matchesType(Type::int()) && !$right->matchesType(Type::float())) {
-                throw TypeError::create(
-                    $left === null
-                        ? sprintf('Can\'t negate %s', $right->getType())
-                        : sprintf('Can\'t subtract %s from %s', $right->getType(), $left->getType()),
-                    $right->location(),
-                );
-            }
-            if ($left === null) {
-                return Expr::negative($right, $parsedToken->location()->to($right->location()));
-            }
-            if (!$left->getType()->equals($right->getType())) {
-                throw TypeError::create(
-                    sprintf('Can\'t subtract %s from %s', $right->getType(), $left->getType()),
-                    $left->location(),
-                );
-            }
-            return $left->subtract($right);
+            return $left === null
+                ? Expr::negative($right, $parsedToken->location()->to($right->location()))
+                : $left->subtract($right);
         }
         if ($token === Token::CloseAngle) {
             if ($left === null) {
                 self::unexpectedToken($parsedToken);
             }
             $this->tokens->next();
-            $right = $this->parseExpressionUntilLogical();
-            if (!$right->matchesType(Type::int()) && !$right->matchesType(Type::float())) {
-                throw TypeError::create(sprintf('Can\'t compare %s to %s', $right->getType(), $left->getType()), $right->location());
-            }
-            if (!$left->matchesType($right->getType())) {
-                throw TypeError::create(sprintf('Can\'t compare %s to %s', $left->getType(), $right->getType()), $left->location()->to($right->location()));
-            }
-            return $left->gt($right);
+            return $left->gt($this->parseExpressionUntilLogical());
         }
         if ($token === Token::OpenBracket) {
             return $this->parseListLiteral();
@@ -416,7 +358,7 @@ final class ExpressionParser
         $token = $this->tokens->peek()?->token;
         return match ($token) {
             Token::Colon, Token::OpenParen => $this->call($name, $nameLocation, $target),
-            default => self::fieldAccess($target, $name, $target->location()->to($nameLocation)),
+            default => Expr::fieldAccess($target, $name, $target->location()->to($nameLocation)),
         };
     }
 
@@ -426,92 +368,51 @@ final class ExpressionParser
      */
     private function call(string $name, Span $nameLocation, Expression $target): Call
     {
-        $fnType = $this->declarations->functions[$name] ?? null;
-        $colonOrOpenParen = $this->tokens->peek();
-        assert($colonOrOpenParen !== null);
-        if ($colonOrOpenParen->token === Token::Colon) {
-            $this->tokens->next();
-            $typeNode = TypeParser::parse($this->tokens);
-            if ($typeNode === null) {
-                throw SyntaxError::create('Expected type after colon', $this->nextSpan());
-            }
-            if ($typeNode instanceof ParsedToken) {
-                throw SyntaxError::create(
-                    sprintf('Expected type after colon, got %s', Token::print($typeNode->token)),
-                    $typeNode->location(),
-                );
-            }
-            $returnType = $this->declarations->types->resolve($typeNode);
-            if ($returnType instanceof TypeError) {
-                throw $returnType;
-            }
-            if ($fnType !== null && !$returnType->isSubtypeOf($fnType->args[0])) {
-                throw TypeError::create(
-                    sprintf(
-                        'Inline return type %s of function %s does not match declared return type %s',
-                        $returnType,
-                        $name,
-                        $fnType->returnType(),
-                    ),
-                    $typeNode->location,
-                );
-            }
-        } else {
-            if ($fnType === null) {
-                throw TypeError::create(
-                    sprintf('Function %s is not declared and has no inline type', $name),
-                    $nameLocation,
-                );
-            }
-            $returnType = $fnType->args[0];
-        }
-        if ($fnType !== null) {
-            $targetType = $fnType->args[1] ?? null;
-            if ($targetType === null) {
-                throw new TypeError(
-                    sprintf('%s can\'t be used as a receiver function because it doesn\'t accept any arguments', $name),
-                );
-            }
-            if (!$target->isSubtypeOf($targetType)) {
-                throw new TypeError(
-                    sprintf(
-                        '%s must be called on an expression of type %s, but %s is of type %s',
-                        $name,
-                        $targetType,
-                        $target,
-                        $target->getType(),
-                    ),
-                );
-            }
-        }
+        $signature = $this->declarations->functions[$name] ?? null;
+        $returnType = $this->returnType();
         $this->expect(Token::OpenParen);
         $args = $this->parseArgs();
         $closeParen = $this->expect(Token::CloseParen);
-        if ($fnType !== null) {
-            $parameterTypes = $fnType->args;
-            array_shift($parameterTypes); // Remove return type
-            array_shift($parameterTypes); // Remove receiver type
-            foreach ($parameterTypes as $index => $parameterType) {
-                $argument = $args[$index] ?? null;
-                if ($argument === null) {
-                    throw new TypeError(
-                        sprintf('%s expects %d arguments, got %d', $name, count($parameterTypes), count($args)),
-                    );
-                }
-                if (!$argument->isSubtypeOf($parameterType)) {
-                    throw new TypeError(
-                        sprintf(
-                            'Argument %d of %s must be of type %s, got %s',
-                            $index + 1,
-                            $name,
-                            $parameterType,
-                            $argument->getType(),
-                        ),
-                    );
-                }
-            }
+        return Expr::call(
+            $target,
+            $name,
+            $returnType,
+            $args,
+            $signature,
+            $nameLocation,
+            $target->location()->to($closeParen->location()),
+        );
+    }
+
+    /**
+     * foo:string.substr:string(0, 3)
+     *                  ======
+     *
+     * Only whether the call site spells a return type out, and which one. Whether it's allowed to leave it out, and
+     * whether the one it spells out fits the function's declaration, is {@see Expr::call()}'s business: those rules hold
+     * for a call however it was built, and a call built through {@see Expression::call()} never comes past here.
+     */
+    private function returnType(): TypeAnnotation|null
+    {
+        if ($this->tokens->peek()?->token !== Token::Colon) {
+            return null;
         }
-        return $target->call($name, $returnType, $args, $target->location()->to($closeParen->location()));
+        $this->expect(Token::Colon);
+        $typeNode = TypeParser::parse($this->tokens);
+        if ($typeNode === null) {
+            throw SyntaxError::create('Expected type after colon', $this->nextSpan());
+        }
+        if ($typeNode instanceof ParsedToken) {
+            throw SyntaxError::create(
+                sprintf('Expected type after colon, got %s', Token::print($typeNode->token)),
+                $typeNode->location(),
+            );
+        }
+        $returnType = $this->declarations->types->resolve($typeNode);
+        if ($returnType instanceof TypeError) {
+            throw $returnType;
+        }
+        return new TypeAnnotation($returnType, $typeNode->location);
     }
 
     /**

--- a/src/Parser/TypeAnnotation.php
+++ b/src/Parser/TypeAnnotation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Parser;
+
+use Eventjet\Ausdruck\Type;
+
+/**
+ * A type the source spells out, together with where it spells it out. Keeping the two together is what lets the type
+ * checker blame the annotation itself when it contradicts a declaration, instead of the expression it annotates.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class TypeAnnotation
+{
+    public function __construct(public readonly Type $type, public readonly Span $location)
+    {
+    }
+}

--- a/src/Subtract.php
+++ b/src/Subtract.php
@@ -7,10 +7,6 @@ namespace Eventjet\Ausdruck;
 use Eventjet\Ausdruck\Parser\Span;
 use Override;
 
-use function get_debug_type;
-use function gettype;
-use function is_float;
-use function is_int;
 use function sprintf;
 
 /**
@@ -28,35 +24,16 @@ final class Subtract extends Expression
         return sprintf('%s - %s', $this->minuend, $this->subtrahend);
     }
 
+    /**
+     * @psalm-suppress InvalidOperand Psalm's strict binary operands mode rejects int|float on either side, because it
+     *     can't see that {@see Expr::subtract()} has already required both operands to be of the *same* numeric type.
+     *     The int/float mix it's guarding against can't reach us.
+     */
     #[Override]
     public function evaluate(Scope $scope): int|float
     {
-        /** @var mixed $minuend */
-        $minuend = $this->minuend->evaluate($scope);
-        /** @var mixed $subtrahend */
-        $subtrahend = $this->subtrahend->evaluate($scope);
-        if (is_int($minuend) && is_int($subtrahend)) {
-            return $minuend - $subtrahend;
-        }
-        if (is_float($minuend) && is_float($subtrahend)) {
-            return $minuend - $subtrahend;
-        }
-        if (gettype($minuend) === gettype($subtrahend)) {
-            throw new EvaluationError(
-                sprintf(
-                    'Expected operands to be of type int or float, got %s and %s',
-                    get_debug_type($minuend),
-                    get_debug_type($subtrahend),
-                ),
-            );
-        }
-        throw new EvaluationError(
-            sprintf(
-                'Expected operands to be of the same type, got %s and %s',
-                get_debug_type($minuend),
-                get_debug_type($subtrahend),
-            ),
-        );
+        return Operand::number($this->minuend->evaluate($scope))
+            - Operand::number($this->subtrahend->evaluate($scope));
     }
 
     #[Override]

--- a/src/Type.php
+++ b/src/Type.php
@@ -81,7 +81,13 @@ final class Type implements Stringable
     }
 
     /**
-     * @param list<Type> $parameters
+     * A function type keeps its return type and its parameters in one list of args: args[0] is the return type, and
+     * everything after it is a parameter. Only returnType() and parameterTypes() know that layout, and everything else,
+     * in this class and outside it, goes through them.
+     *
+     * @param list<Type> $parameters The types the PHP callable receives, in order. A function that is called as a
+     *     receiver function -- `foo:string.substr:string(0, 3)` -- receives the expression it's called on as the first
+     *     of them; see receiverType() and argumentTypes().
      */
     public static function func(self $return, array $parameters = []): self
     {
@@ -285,6 +291,30 @@ final class Type implements Stringable
         return $this->args[0];
     }
 
+    /**
+     * The type a receiver function is called on: `substr` is declared as func(string, [string, int, int]) and called as
+     * `foo:string.substr:string(0, 3)`, so its receiver type is string. Null if the function declares no parameters at
+     * all, which is what makes it unusable as a receiver function.
+     *
+     * This should only be called on function types. The behavior is undefined for other types.
+     */
+    public function receiverType(): self|null
+    {
+        return $this->parameterTypes()[0] ?? null;
+    }
+
+    /**
+     * The types of the arguments a call passes in parentheses, which are the parameters the receiver doesn't take up.
+     *
+     * This should only be called on function types. The behavior is undefined for other types.
+     *
+     * @return list<self>
+     */
+    public function argumentTypes(): array
+    {
+        return array_slice($this->parameterTypes(), 1);
+    }
+
     public function isStruct(): bool
     {
         return $this->canonical()->name === 'Struct';
@@ -296,6 +326,10 @@ final class Type implements Stringable
     }
 
     /**
+     * Every parameter of a function type, receiver included, in the order the PHP callable receives them. Two function
+     * types are compared parameter by parameter, so this is the list that matters for subtyping; the split into a
+     * receiver and the arguments only matters at a call site.
+     *
      * @return list<self>
      */
     private function parameterTypes(): array

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -56,8 +56,13 @@ final class ExpressionComparisonTest extends TestCase
             Expr::gt(Expr::literal(1), Expr::literal(2)),
         ];
         yield [
+            Expr::negative(Expr::get('a', Type::int())),
+            Expr::negative(Expr::get('a', Type::int())),
+        ];
+        // A negated number literal is a negative number literal, not a negation of a positive one.
+        yield [
             Expr::negative(Expr::literal(1)),
-            Expr::negative(Expr::literal(1)),
+            Expr::literal(-1),
         ];
         yield [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),
@@ -191,27 +196,27 @@ final class ExpressionComparisonTest extends TestCase
             Expr::literal(1),
         ];
         yield Call::class . ': target is different' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), []),
-            Expr::call(Expr::literal(2), 'foo', Type::int(), []),
+            Expr::literal(1)->call('foo', Type::int(), []),
+            Expr::literal(2)->call('foo', Type::int(), []),
         ];
         yield Call::class . ': name is different' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), []),
-            Expr::call(Expr::literal(1), 'bar', Type::int(), []),
+            Expr::literal(1)->call('foo', Type::int(), []),
+            Expr::literal(1)->call('bar', Type::int(), []),
         ];
         yield Call::class . ': type is different' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), []),
-            Expr::call(Expr::literal(1), 'foo', Type::string(), []),
+            Expr::literal(1)->call('foo', Type::int(), []),
+            Expr::literal(1)->call('foo', Type::string(), []),
         ];
         yield Call::class . ': different number of arguments' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), []),
-            Expr::call(Expr::literal(1), 'foo', Type::int(), [Expr::literal(1)]),
+            Expr::literal(1)->call('foo', Type::int(), []),
+            Expr::literal(1)->call('foo', Type::int(), [Expr::literal(1)]),
         ];
         yield Call::class . ': argument is different' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), [Expr::literal(1), Expr::literal(2), Expr::literal(3)]),
-            Expr::call(Expr::literal(1), 'foo', Type::int(), [Expr::literal(1), Expr::literal(9), Expr::literal(3)]),
+            Expr::literal(1)->call('foo', Type::int(), [Expr::literal(1), Expr::literal(2), Expr::literal(3)]),
+            Expr::literal(1)->call('foo', Type::int(), [Expr::literal(1), Expr::literal(9), Expr::literal(3)]),
         ];
         yield Call::class . ': different type' => [
-            Expr::call(Expr::literal(1), 'foo', Type::int(), []),
+            Expr::literal(1)->call('foo', Type::int(), []),
             Expr::literal(1),
         ];
         yield Gt::class . ': left is different' => [
@@ -231,12 +236,12 @@ final class ExpressionComparisonTest extends TestCase
             Expr::eq(Expr::literal(1), Expr::literal(2)),
         ];
         yield Negative::class . ': different type' => [
-            Expr::negative(Expr::literal(1)),
-            Expr::literal(1),
+            Expr::negative(Expr::get('a', Type::int())),
+            Expr::get('a', Type::int()),
         ];
         yield Negative::class . ': different expression' => [
-            Expr::negative(Expr::literal(1)),
-            Expr::negative(Expr::literal(2)),
+            Expr::negative(Expr::get('a', Type::int())),
+            Expr::negative(Expr::get('b', Type::int())),
         ];
         yield ListLiteral::class . ': different elements' => [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),
@@ -257,7 +262,7 @@ final class ExpressionComparisonTest extends TestCase
         ];
         yield FieldAccess::class . ': different type' => [
             Expr::fieldAccess(Expr::get('person', $personType), 'name', self::location()),
-            Expr::call(Expr::get('person', $personType), 'name', Type::string(), []),
+            Expr::get('person', $personType)->call('name', Type::string(), []),
         ];
         yield StructLiteral::class . ': different type' => [
             new StructLiteral(['foo' => Expr::literal('bar')], self::location()),

--- a/tests/unit/ExpressionTest.php
+++ b/tests/unit/ExpressionTest.php
@@ -10,7 +10,6 @@ use Eventjet\Ausdruck\Expression;
 use Eventjet\Ausdruck\Literal;
 use Eventjet\Ausdruck\Parser\Declarations;
 use Eventjet\Ausdruck\Parser\ExpressionParser;
-use Eventjet\Ausdruck\Parser\Span;
 use Eventjet\Ausdruck\Parser\Types;
 use Eventjet\Ausdruck\Scope;
 use Eventjet\Ausdruck\Type;
@@ -142,6 +141,10 @@ final class ExpressionTest extends TestCase
             ['items:list<string>.take:list<string>(3)', new Scope(['items' => []]), []],
             ['items:list<string>.take:list<string>(0)', new Scope(['items' => ['a', 'b', 'c', 'd', 'e']]), []],
             ['-myval:int', new Scope(['myval' => 42]), -42],
+            // && and || short-circuit. "b" is deliberately missing from the scope: evaluating it would throw, so these
+            // only pass if the right operand is never touched.
+            ['a:bool || b:bool', new Scope(['a' => true]), true],
+            ['a:bool && b:bool', new Scope(['a' => false]), false],
             [
                 'names:list<string>.map:list<bool>(|name| name:string === "bar")',
                 new Scope(['names' => ['foo', 'bar', 'baz']]),
@@ -162,7 +165,8 @@ final class ExpressionTest extends TestCase
                 md5('mystrtest'),
                 new Declarations(
                     variables: ['foo' => Type::string()],
-                    functions: ['customHash' => Type::func(Type::string(), [Type::string()])],
+                    // The receiver is the text, the argument is the salt.
+                    functions: ['customHash' => Type::func(Type::string(), [Type::string(), Type::string()])],
                 ),
             ],
             (static function () {
@@ -239,31 +243,19 @@ final class ExpressionTest extends TestCase
             ['{name: "John"}.name', new Scope(), 'John'],
             ['{name: "John", age: 37}.age', new Scope(), 37],
             ['{name: "John", age: 37,}.age', new Scope(), 37],
-            [
-                Expr::eq(Expr::structLiteral(['name' => Expr::literal('John')], self::span()), Expr::literal('John')),
-                new Scope(),
-                false,
-            ],
-            [
-                Expr::eq(Expr::literal('John'), Expr::structLiteral(['name' => Expr::literal('John')], self::span())),
-                new Scope(),
-                false,
-            ],
+            // Two operands only have to be of the same type to be compared, and any is a type. Structs are therefore the
+            // one place where === has to compare values it knows nothing about statically.
+            ['left:any === right:any', new Scope(['left' => (object)['name' => 'John'], 'right' => 'John']), false],
+            ['left:any === right:any', new Scope(['left' => 'John', 'right' => (object)['name' => 'John']]), false],
             ['{name: "John"} === {name: "Jane"}', new Scope(), false],
             [
-                Expr::eq(
-                    Expr::structLiteral(['a' => Expr::literal('A'), 'b' => Expr::literal('B')], self::span()),
-                    Expr::structLiteral(['a' => Expr::literal('A'), 'c' => Expr::literal('C')], self::span()),
-                ),
-                new Scope(),
+                'left:any === right:any',
+                new Scope(['left' => (object)['a' => 'A', 'b' => 'B'], 'right' => (object)['a' => 'A', 'c' => 'C']]),
                 false,
             ],
             [
-                Expr::eq(
-                    Expr::structLiteral(['a' => Expr::literal('A'), 'c' => Expr::literal('C')], self::span()),
-                    Expr::structLiteral(['a' => Expr::literal('A'), 'b' => Expr::literal('B')], self::span()),
-                ),
-                new Scope(),
+                'left:any === right:any',
+                new Scope(['left' => (object)['a' => 'A', 'c' => 'C'], 'right' => (object)['a' => 'A', 'b' => 'B']]),
                 false,
             ],
             [
@@ -404,56 +396,8 @@ final class ExpressionTest extends TestCase
             new Scope(['foo' => 'test'], ['chars' => static fn(string $text): string => $text]),
             'Expected int, got string',
         ];
-        yield 'Subtracting a float from an integer' => [
-            Expr::subtract(Expr::get('myint', Type::int()), Expr::get('myfloat', Type::float())),
-            new Scope(['myint' => 42, 'myfloat' => 23.42]),
-            'Expected operands to be of the same type, got int and float',
-        ];
-        yield 'Subtracting an integer from a float' => [
-            Expr::subtract(Expr::get('myfloat', Type::float()), Expr::get('myint', Type::int())),
-            new Scope(['myint' => 42, 'myfloat' => 23.42]),
-            'Expected operands to be of the same type, got float and int',
-        ];
-        yield 'Subtracting a string from a string' => [
-            Expr::subtract(Expr::get('mystr', Type::string()), Expr::get('mystr2', Type::string())),
-            new Scope(['mystr' => 'foo', 'mystr2' => 'bar']),
-            'Expected operands to be of type int or float, got string and string',
-        ];
-        yield 'Logical or with string on the left' => [
-            Expr::get('foo', Type::string())->or_(Expr::get('bar', Type::bool())),
-            new Scope(['foo' => 'foo', 'bar' => true]),
-            'Expected boolean operands, got string and bool',
-        ];
-        yield 'Logical or with string on the right' => [
-            Expr::get('foo', Type::bool())->or_(Expr::get('bar', Type::string())),
-            new Scope(['foo' => true, 'bar' => 'bar']),
-            'Expected boolean operands, got bool and string',
-        ];
-        yield 'Logical and with string on the left' => [
-            Expr::get('foo', Type::string())->and_(Expr::get('bar', Type::bool())),
-            new Scope(['foo' => 'foo', 'bar' => true]),
-            'Expected boolean operands, got string and bool',
-        ];
-        yield 'Logical and with string on the right' => [
-            Expr::get('foo', Type::bool())->and_(Expr::get('bar', Type::string())),
-            new Scope(['foo' => true, 'bar' => 'bar']),
-            'Expected boolean operands, got bool and string',
-        ];
-        yield 'Negative bool' => [
-            Expr::negative(Expr::get('foo', Type::bool())),
-            new Scope(['foo' => true]),
-            'Expected operand to be of type int or float',
-        ];
-        yield 'Access non-existent struct field' => [
-            Expr::fieldAccess(Expr::get('user', Type::struct(['name' => Type::string()])), 'age', self::span()),
-            new Scope(['user' => (object)['name' => 'John']]),
-            'Unknown field "age"',
-        ];
-        yield 'Access field non non-struct' => [
-            Expr::fieldAccess(Expr::get('user', Type::string()), 'name', self::span()),
-            new Scope(['user' => 'John']),
-            'Expected object, got string',
-        ];
+        // Operands of the wrong type are rejected by Expr when the node is built, so there are no evaluation-time cases
+        // for them. See ExpressionParserTest::typeErrorExpressions().
         yield 'String does not accept empty PHP array' => [
             ['foo:string'],
             new Scope(['foo' => []]),
@@ -537,11 +481,6 @@ final class ExpressionTest extends TestCase
     private static function firstElement(array $array): mixed
     {
         return $array[0];
-    }
-
-    private static function span(): Span
-    {
-        return Span::char(1, 1);
     }
 
     private static function struct(mixed ...$fields): object

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -158,19 +158,33 @@ final class ExpressionParserTest extends TestCase
     public static function typeErrorExpressions(): iterable
     {
         yield 'map type with bool key type' => ['foo:map<bool, string>'];
-        yield 'or with string on the left' => ['foo:string || bar:bool'];
-        yield 'or with string on the right' => ['foo:bool || bar:string'];
+        yield 'or with string on the left' => [
+            'foo:string || bar:bool',
+            'The expression on the left side of || must be boolean, got string',
+        ];
+        yield 'or with string on the right' => [
+            'foo:bool || bar:string',
+            'The expression on the right side of || must be boolean, got string',
+        ];
+        yield 'and with string on the left' => [
+            'foo:string && bar:bool',
+            'The expression on the left side of && must be boolean, got string',
+        ];
+        yield 'and with string on the right' => [
+            'foo:bool && bar:string',
+            'The expression on the right side of && must be boolean, got string',
+        ];
         yield 'equals: different operand types' => ['foo:string === bar:int'];
         yield 'subtract int from float' => ['foo:float - bar:int', 'Can\'t subtract int from float'];
         yield 'subtract float from int' => ['foo:int - bar:float', 'Can\'t subtract float from int'];
         yield 'subtract string from string' => ['foo:string - bar:string', 'Can\'t subtract string from string'];
         yield 'subtract string from int' => ['foo:int - bar:string', 'Can\'t subtract string from int'];
         yield 'subtract int from string' => ['foo:string - bar:int', 'Can\'t subtract int from string'];
-        yield 'int > float' => ['foo:int > bar:float'];
-        yield 'float > int' => ['foo:float > bar:int'];
-        yield 'string > string' => ['foo:string > bar:string'];
-        yield 'string > int' => ['foo:string > bar:int'];
-        yield 'int > string' => ['foo:int > bar:string'];
+        yield 'int > float' => ['foo:int > bar:float', 'Can\'t compare int to float'];
+        yield 'float > int' => ['foo:float > bar:int', 'Can\'t compare float to int'];
+        yield 'string > string' => ['foo:string > bar:string', 'Can\'t compare string to string'];
+        yield 'string > int' => ['foo:string > bar:int', 'Can\'t compare string to int'];
+        yield 'int > string' => ['foo:int > bar:string', 'Can\'t compare string to int'];
         yield 'generic syntax on string' => ['foo:string<int>'];
         yield 'unknown variable type' => ['foo:notavalidtype'];
         yield 'map with no type arguments' => ['foo:map', 'The map type requires two arguments, none given'];
@@ -215,6 +229,15 @@ final class ExpressionParserTest extends TestCase
         yield 'too few function arguments' => [
             'foo:string.substr(0)',
             'substr expects 2 arguments, got 1',
+        ];
+        yield 'too many function arguments' => [
+            'foo:string.substr(0, 3, 9)',
+            'substr expects 2 arguments, got 3',
+        ];
+        yield 'arguments passed to a function that only takes a receiver' => [
+            'foo:string.myCustomFn(42)',
+            'myCustomFn expects 0 arguments, got 1',
+            new Declarations(functions: ['myCustomFn' => Type::func(Type::string(), [Type::string()])]),
         ];
         yield 'wrong argument type' => [
             'foo:string.substr(0, "3")',
@@ -373,9 +396,15 @@ final class ExpressionParserTest extends TestCase
     public static function typeErrorLocationCases(): iterable
     {
         $cases = [
+            // > and - enforce the same rule -- both operands numeric and of the same type -- so they blame the same
+            // operand for the same mistake. Compare the pair below with the '42 - "foo"' / '"foo" - 42' pair.
             [
                 '42 > "foo"',
                 '     =====',
+            ],
+            [
+                '"foo" > 42',
+                '=====     ',
             ],
             [
                 'x:list<string, int>',
@@ -432,6 +461,37 @@ final class ExpressionParserTest extends TestCase
             [
                 'foo:Option<string, int, bool>',
                 '                   ========= ',
+            ],
+            // Calls are checked against the function's declared signature, so their type errors point at the operand
+            // that doesn't fit it: the receiver, or the argument. A missing argument has no location of its own, so
+            // the error spans the whole call; one too many is right there to point at.
+            [
+                'foo:int.substr(0, 3)',
+                '=======             ',
+            ],
+            [
+                'x:int.contains(42)',
+                '=====             ',
+            ],
+            [
+                'foo:string.substr(0)',
+                '====================',
+            ],
+            [
+                'foo:string.substr(0, 3, 9)',
+                '                        = ',
+            ],
+            [
+                'foo:string.substr(0, "3")',
+                '                     === ',
+            ],
+            [
+                'x:list<string>.some("foo")',
+                '                    =====  ',
+            ],
+            [
+                'x:string.foo()',
+                '         ===  ',
             ],
         ];
         foreach ($cases as [$expression, $location]) {


### PR DESCRIPTION
Split from #52.

Every node was checking its operands twice: the parser checked them while building the tree, and the node checked them again on every `evaluate()`. The two copies of each rule could drift, and the second one ran against values the first had already proven safe.

Every rule now lives in `Expr`, the only place nodes are constructed. An expression that exists is one whose operands type-check, so the nodes stop re-checking — they only narrow the `mixed` their sub-expressions hand back, through the new `Operand`, to the type PHP needs to apply the operator.

Two consequences worth calling out:

- **`&&` and `||` short-circuit now**, because they no longer have to evaluate both operands up front in order to check them.
- **A `Call`'s return type is resolved rather than handed to it**, from its inline annotation and the function's declaration, so a `Call` can't contradict its own signature. `Expr::call()` takes both; the new `TypeAnnotation` carries the annotation's location so an error can blame the annotation itself.

Error messages and locations move with the rules, which is most of the test diff. `ExpressionTest`'s evaluation-time type errors are gone: those operands are now rejected when the node is built, so they are parser test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)