### PR TITLE
Never fold the sign into a number literal

### DIFF
--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -86,9 +86,14 @@ final class Tokenizer
                 yield new ParsedToken($token, $line, $startCol);
                 continue;
             }
-            if ($char === '-' || is_numeric($char)) {
+            if ($char === '-') {
                 $startCol = $column;
-                yield new ParsedToken(self::numberOrArrow($chars, $column), $line, $startCol);
+                yield new ParsedToken(self::minusOrArrow($chars, $column), $line, $startCol);
+                continue;
+            }
+            if (is_numeric($char)) {
+                $startCol = $column;
+                yield new ParsedToken(self::number($chars, $column), $line, $startCol);
                 continue;
             }
             if ($char === '|') {
@@ -198,34 +203,41 @@ final class Tokenizer
     }
 
     /**
+     * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
+     * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one. If the sign
+     * were folded in here, whitespace would silently decide the meaning of `a -2`: subtraction, or `a` followed by the
+     * literal -2.
+     *
      * @param Peekable<string> $chars
      * @param positive-int $column
-     * @return Literal<int | float> | Token
      */
-    private static function numberOrArrow(Peekable $chars, int &$column): Literal|Token
+    private static function minusOrArrow(Peekable $chars, int &$column): Token
+    {
+        $chars->next();
+        $column++;
+        if ($chars->peek() !== '>') {
+            return Token::Minus;
+        }
+        $chars->next();
+        return Token::Arrow;
+    }
+
+    /**
+     * @param Peekable<string> $chars
+     * @param positive-int $column
+     * @return Literal<int | float>
+     */
+    private static function number(Peekable $chars, int &$column): Literal
     {
         $number = '';
         while (true) {
             $char = $chars->peek();
-            if ($number === '' && $char === '-') {
-                $number = $char;
-                $chars->next();
-                $column++;
-                continue;
-            }
-            if ($number === '-' && $char === '>') {
-                $chars->next();
-                return Token::Arrow;
-            }
             if ($char === null || !is_numeric($number . $char)) {
                 break;
             }
             $number .= $char;
             $chars->next();
             $column++;
-        }
-        if ($number === '-') {
-            return Token::Minus;
         }
         return new Literal(str_contains($number, '.') ? (float)$number : (int)$number);
     }

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -79,6 +79,10 @@ final class ExpressionParserTest extends TestCase
                 Expr::lambda(Expr::get('foo', Type::bool())->or_(Expr::get('bar', Type::bool())), ['foo', 'bar']),
             ],
             ['69-foo:int', Expr::literal(69)->subtract(Expr::get('foo', Type::int()))],
+            // Whitespace must not decide whether the minus is a subtraction or the sign of a literal.
+            ['foo:int-2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
+            ['foo:int -2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
+            ['foo:int- 2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
             [
                 // Newline after variable type
                 '

--- a/tests/unit/cases/subtract/space-only-before-operator.txt
+++ b/tests/unit/cases/subtract/space-only-before-operator.txt
@@ -1,0 +1,7 @@
+a:int -2
+-- Input --
+{
+  a: 5,
+}
+-- Output --
+3

--- a/tests/unit/cases/subtract/without-spaces.txt
+++ b/tests/unit/cases/subtract/without-spaces.txt
@@ -1,0 +1,7 @@
+a:int-2
+-- Input --
+{
+  a: 5,
+}
+-- Output --
+3


### PR DESCRIPTION
## Summary
- The tokenizer no longer folds a leading `-` into a number literal: a `-` always yields `Token::Minus`, and `Expr::negative()` folds a negated number literal back into a negative one, so `-2` is still the literal `-2` wherever it really is one.
- Fixes `a:int -2` silently evaluating to `-2`, dropping the `a` entirely — whitespace could decide whether a minus was a subtraction or a literal's sign.
- Pins `foo:int-2`, `foo:int -2`, and `foo:int- 2` to the same subtraction, with parser tests and end-to-end cases.

## Details
The tokenizer read `-2` as the literal `-2`, which let whitespace silently decide what `a:int -2` meant: it saw `a` followed by the literal `-2`, the parser had no operator to join them with, and the whole expression evaluated to `-2`. The `a` was dropped without a word.

`numberOrArrow()` is split into `minusOrArrow()` and `number()` so the two decisions are made independently. What the tokenizer can't tell apart, the parser can: by the time it negates, it knows the minus had no left operand.

Split from #52. The `Expr::negative()` fold this relies on landed in #54, which is now merged, and this branch is rebased onto `0.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)