### PR TITLE
Pin that nested positions parse a whole expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ As in most languages, `&&` binds tighter than `||`, so `a:bool && b:bool || c:bo
 
 There are no grouping parentheses yet, so you can't override the precedence.
 
-Operators are allowed anywhere an expression is expected, not only at the top level. List items, struct field values,
-function arguments, and lambda bodies are all full expressions:
+Anywhere an expression is expected, it can be a whole one, not only at the top level. List items, struct field values,
+function arguments, and lambda bodies are all full expressions, so operators, calls, and field access are available in
+all of them:
 
 ```
 [a:int - 1, 10]
 {total: a:int - b:int}
 foo:string.substr(a:int - 1, 2)
+names:list<string>.contains:bool(user:{ name: string }.name)
+{matches: needle:string === haystack:string.substr:string(0, 1) || always:bool}
 ```
 
 ### Types

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -30,6 +30,20 @@ final class ExpressionParserTest extends TestCase
         $s = Type::string();
         $b = Type::bool();
         $i = Type::int();
+        /**
+         * One expression that spans the entire cascade: || is its loosest level, and the postfix . of a field access
+         * and of a call its tightest. A position that parses it has to run every level in between, because that's the
+         * only way down from || to the dot. Nesting it below is therefore a stronger statement than nesting any single
+         * operator would be, and the reason there's no case per operator down there.
+         */
+        $wholeCascade = 'o:{ n: string }.n === s:string.substr:string(0, 1) || b:bool';
+        $wholeCascadeExpr = Expr::or_(
+            Expr::eq(
+                Expr::fieldAccess(Expr::get('o', Type::struct(['n' => $s])), 'n', Span::char(1, 1)),
+                Expr::get('s', $s)->call('substr', $s, [Expr::literal(0), Expr::literal(1)]),
+            ),
+            Expr::get('b', $b),
+        );
         $cases = [
             ['foo:string', Expr::get('foo', $s)],
             ['"my-literal"', Expr::literal('my-literal')],
@@ -136,6 +150,25 @@ final class ExpressionParserTest extends TestCase
                     'substr',
                     $s,
                     [Expr::subtract(Expr::literal(5), Expr::literal(3)), Expr::literal(2)],
+                ),
+            ],
+            // A call argument, a list item and a struct field value are full expressions, like a lambda body: each is
+            // parsed by parseExpression() rather than by some smaller grammar of its own. The item and field cases put
+            // a second element after the nested expression, because the operators in it must not swallow the comma
+            // that ends it.
+            [
+                sprintf('xs:list<bool>.contains:bool(%s)', $wholeCascade),
+                Expr::get('xs', Type::listOf($b))->call('contains', $b, [$wholeCascadeExpr]),
+            ],
+            [
+                sprintf('[%s, false]', $wholeCascade),
+                Expr::listLiteral([$wholeCascadeExpr, Expr::literal(false)], Span::char(1, 1)),
+            ],
+            [
+                sprintf('{matches: %s, fallback: b:bool}', $wholeCascade),
+                Expr::structLiteral(
+                    ['matches' => $wholeCascadeExpr, 'fallback' => Expr::get('b', $b)],
+                    Span::char(1, 1),
                 ),
             ],
         ];

--- a/tests/unit/cases/nested-expression/in-call-argument.txt
+++ b/tests/unit/cases/nested-expression/in-call-argument.txt
@@ -1,0 +1,10 @@
+xs:list<bool>.contains:bool(o:{ n: string }.n === s:string.substr:string(0, 1) || b:bool)
+-- Input --
+{
+  xs: [true],
+  o: {n: "a"},
+  s: "xyz",
+  b: true,
+}
+-- Output --
+true

--- a/tests/unit/cases/nested-expression/in-list-item.txt
+++ b/tests/unit/cases/nested-expression/in-list-item.txt
@@ -1,0 +1,9 @@
+[o:{ n: string }.n === s:string.substr:string(0, 1) || b:bool, false]
+-- Input --
+{
+  o: {n: "a"},
+  s: "xyz",
+  b: true,
+}
+-- Output --
+[true, false]

--- a/tests/unit/cases/nested-expression/in-struct-field.txt
+++ b/tests/unit/cases/nested-expression/in-struct-field.txt
@@ -1,0 +1,9 @@
+{matches: o:{ n: string }.n === s:string.substr:string(0, 1) || b:bool, fallback: b:bool}
+-- Input --
+{
+  o: {n: "a"},
+  s: "xyz",
+  b: true,
+}
+-- Output --
+{matches: true, fallback: true}


### PR DESCRIPTION
Closes #45.

### The bug is already fixed

Every reproduction in #45 parses and evaluates today. Parsing expressions as a precedence cascade (ef9db06, #56) fixed it as a side effect: `parseArg()`, `parseListLiteral()` and `parseStructField()` went from a single `parseLazy(null)` pass to `parseExpression()`, which is exactly the fix the issue prescribes. Nothing under `src/` changes here.

### What was missing

That commit witnessed those positions with `-` alone, and `-` was never what the issue was about — it reports calls, field access, and comparison/logical operators.

The gap was real, not hypothetical: downgrading all three positions to `parseAdditive()` — which still takes the `-` of the existing cases and the `.` of a postfix, but no `===` and no `||` — leaves the entire pre-existing suite green. Nothing pinned how far the cascade reaches into those positions, so a later parser change could have put the reported bug back with no test complaining.

### What this adds

One expression that spans the whole cascade, nested in each of the three positions:

```
o:{ n: string }.n === s:string.substr:string(0, 1) || b:bool
```

`||` is the cascade's loosest level, and the postfix `.` of a field access and of a call its tightest, so a position that parses it has to run every level in between. That says more than a case per operator would, and covers what the issue reports in one go. The list and struct cases put a second element behind it, because the operators in it must not swallow the comma that ends it.

Three parse cases pin the AST, three end-to-end cases pin evaluation. Each is load-bearing and position-specific: downgrading one position's parser fails exactly that position's two tests and no others, and under the `parseAdditive()` downgrade above only these six fail.

The README claimed only that *operators* were allowed in those positions, and showed it with `-` alone; it now says calls and field access are too.

### Verification

`composer check` is green: php-cs-fixer, Psalm, PHPStan, 603 PHPUnit tests, and Infection at 100% MSI / 100% covered MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)