### PR TITLE
Make a string entry point consume its whole input

### DIFF
--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -69,22 +69,16 @@ final class ExpressionParser
         );
     }
 
-    private static function unexpectedToken(ParsedToken $token): never
-    {
-        throw SyntaxError::create(
-            is_string($token->token)
-                ? sprintf('Unexpected identifier %s', $token->token)
-                : sprintf('Unexpected %s', Token::print($token->token)),
-            $token->location(),
-        );
-    }
-
+    /**
+     * The entire input has to be a single expression. Stopping at the first complete one and dropping the rest would
+     * make `42 < 23` — a comparison the language doesn't have — a roundabout way of writing `42`.
+     */
     private function parseComplete(): Expression
     {
         $expression = $this->parseExpression();
         $trailing = $this->tokens->peek();
         if ($trailing !== null) {
-            self::unexpectedToken($trailing);
+            throw SyntaxError::unexpectedToken($trailing);
         }
         return $expression;
     }

--- a/src/Parser/SyntaxError.php
+++ b/src/Parser/SyntaxError.php
@@ -7,6 +7,9 @@ namespace Eventjet\Ausdruck\Parser;
 use RuntimeException;
 use Throwable;
 
+use function is_string;
+use function sprintf;
+
 final class SyntaxError extends RuntimeException
 {
     public function __construct(
@@ -21,5 +24,19 @@ final class SyntaxError extends RuntimeException
     public static function create(string $message, Span $location): self
     {
         return new self($message, location: $location);
+    }
+
+    /**
+     * A token in a position where the grammar has nothing left to do with it. Identifiers are named as such, because
+     * printing them bare would make `true false` read as if `false` were a symbol.
+     */
+    public static function unexpectedToken(ParsedToken $token): self
+    {
+        return self::create(
+            is_string($token->token)
+                ? sprintf('Unexpected identifier %s', $token->token)
+                : sprintf('Unexpected %s', Token::print($token->token)),
+            $token->location(),
+        );
     }
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -44,6 +44,44 @@ final class TypeParser
     }
 
     /**
+     * A sequence of `Name: <type>` declarations. A type ends where it is complete, so the next declaration's name is
+     * simply the next token; no separator is needed between them.
+     *
+     * @return array<string, TypeNode>
+     */
+    public static function parseDeclarations(string $src): array
+    {
+        $tokens = new Peekable(Tokenizer::tokenize($src === '' ? [] : str_split($src)));
+        $declarations = [];
+        while (($nameToken = $tokens->peek()) !== null) {
+            $name = $nameToken->token;
+            if (!is_string($name)) {
+                throw SyntaxError::create(
+                    sprintf('Expected type name, got %s', Token::print($name)),
+                    $nameToken->location(),
+                );
+            }
+            $tokens->next();
+            self::expect($tokens, Token::Colon);
+            $node = self::parse($tokens);
+            if ($node === null) {
+                throw SyntaxError::create(
+                    sprintf('Expected a type for %s, got end of input', $name),
+                    $nameToken->location(),
+                );
+            }
+            if (!$node instanceof TypeNode) {
+                throw SyntaxError::create(
+                    sprintf('Expected a type for %s, got %s', $name, Token::print($node->token)),
+                    $node->location(),
+                );
+            }
+            $declarations[$name] = $node;
+        }
+        return $declarations;
+    }
+
+    /**
      * @param Peekable<ParsedToken> $tokens
      */
     public static function parse(Peekable $tokens): TypeNode|ParsedToken|null

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -16,11 +16,17 @@ use function str_split;
  */
 final class TypeParser
 {
+    /**
+     * A whole string is a whole type: unlike {@see self::parse()}, which reads one type off a stream the expression
+     * parser keeps using afterwards, nothing here comes after the type, so a leftover token is an error rather than the
+     * caller's business.
+     */
     public static function parseString(string $str): TypeNode|SyntaxError
     {
         $chars = $str === '' ? [] : str_split($str);
+        $tokens = new Peekable(Tokenizer::tokenize($chars));
         try {
-            $node = self::parse(new Peekable(Tokenizer::tokenize($chars)));
+            $node = self::parse($tokens);
         } catch (SyntaxError $e) {
             return $e;
         }
@@ -29,6 +35,10 @@ final class TypeParser
         }
         if ($node === null) {
             return SyntaxError::create('Invalid type ""', Span::char(1, 1));
+        }
+        $trailing = $tokens->peek();
+        if ($trailing !== null) {
+            return SyntaxError::unexpectedToken($trailing);
         }
         return $node;
     }

--- a/tests/unit/E2eCase.php
+++ b/tests/unit/E2eCase.php
@@ -6,11 +6,7 @@ namespace Eventjet\Ausdruck\Test\Unit;
 
 use Eventjet\Ausdruck\AbstractLiteral;
 use Eventjet\Ausdruck\Parser\ExpressionParser;
-use Eventjet\Ausdruck\Parser\Peekable;
-use Eventjet\Ausdruck\Parser\Token;
-use Eventjet\Ausdruck\Parser\Tokenizer;
 use Eventjet\Ausdruck\Parser\TypeError;
-use Eventjet\Ausdruck\Parser\TypeNode;
 use Eventjet\Ausdruck\Parser\TypeParser;
 use Eventjet\Ausdruck\Parser\Types;
 use Eventjet\Ausdruck\StructLiteral;
@@ -25,11 +21,9 @@ use function array_key_exists;
 use function explode;
 use function file_get_contents;
 use function implode;
-use function is_string;
 use function sprintf;
 use function str_ends_with;
 use function str_replace;
-use function str_split;
 use function str_starts_with;
 use function strlen;
 use function substr;
@@ -125,42 +119,25 @@ final readonly class E2eCase
     }
 
     /**
-     * A Types section is a sequence of `Name: <type>` declarations. They're read off a single token stream, because
-     * that's what the type parser works on: it stops when the type is complete and leaves the stream on the next
-     * declaration's name. Each type is resolved against the aliases declared before it, so `Bag` can be a struct of
-     * `Item`s.
+     * A Types section is a sequence of `Name: <type>` declarations. Each type is resolved against the aliases declared
+     * before it, so `Bag` can be a struct of `Item`s.
      *
      * @return array<string, Type>
      */
     private static function parseTypes(string $src): array
     {
-        $tokens = new Peekable(Tokenizer::tokenize($src === '' ? [] : str_split($src)));
         $aliases = [];
-        while (true) {
-            $name = $tokens->next();
-            if ($name === null) {
-                return $aliases;
-            }
-            if (!is_string($name->token)) {
-                throw new RuntimeException(sprintf('Expected a type name, got %s', Token::print($name->token)));
-            }
-            $colon = $tokens->next();
-            if ($colon?->token !== Token::Colon) {
-                throw new RuntimeException(sprintf('Expected a colon after the type name %s', $name->token));
-            }
-            /**
-             * @psalm-suppress InternalClass
-             * @psalm-suppress InternalMethod
-             */
-            $node = TypeParser::parse($tokens);
-            if (!$node instanceof TypeNode) {
-                throw new RuntimeException(sprintf('Expected a type for %s', $name->token));
-            }
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
+        foreach (TypeParser::parseDeclarations($src) as $name => $node) {
             $type = (new Types($aliases))->resolve($node);
             if ($type instanceof TypeError) {
                 throw $type;
             }
-            $aliases[$name->token] = $type;
+            $aliases[$name] = $type;
         }
+        return $aliases;
     }
 }

--- a/tests/unit/E2eCase.php
+++ b/tests/unit/E2eCase.php
@@ -6,8 +6,11 @@ namespace Eventjet\Ausdruck\Test\Unit;
 
 use Eventjet\Ausdruck\AbstractLiteral;
 use Eventjet\Ausdruck\Parser\ExpressionParser;
-use Eventjet\Ausdruck\Parser\SyntaxError;
+use Eventjet\Ausdruck\Parser\Peekable;
+use Eventjet\Ausdruck\Parser\Token;
+use Eventjet\Ausdruck\Parser\Tokenizer;
 use Eventjet\Ausdruck\Parser\TypeError;
+use Eventjet\Ausdruck\Parser\TypeNode;
 use Eventjet\Ausdruck\Parser\TypeParser;
 use Eventjet\Ausdruck\Parser\Types;
 use Eventjet\Ausdruck\StructLiteral;
@@ -19,18 +22,17 @@ use RuntimeException;
 use SplFileInfo;
 
 use function array_key_exists;
-use function array_splice;
-use function count;
 use function explode;
 use function file_get_contents;
 use function implode;
+use function is_string;
 use function sprintf;
 use function str_ends_with;
 use function str_replace;
+use function str_split;
 use function str_starts_with;
 use function strlen;
 use function substr;
-use function trim;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -123,36 +125,42 @@ final readonly class E2eCase
     }
 
     /**
+     * A Types section is a sequence of `Name: <type>` declarations. They're read off a single token stream, because
+     * that's what the type parser works on: it stops when the type is complete and leaves the stream on the next
+     * declaration's name. Each type is resolved against the aliases declared before it, so `Bag` can be a struct of
+     * `Item`s.
+     *
      * @return array<string, Type>
      */
     private static function parseTypes(string $src): array
     {
+        $tokens = new Peekable(Tokenizer::tokenize($src === '' ? [] : str_split($src)));
         $aliases = [];
-        $types = new Types();
         while (true) {
-            $parts = explode(':', $src, 2);
-            if (count($parts) !== 2) {
-                break;
+            $name = $tokens->next();
+            if ($name === null) {
+                return $aliases;
             }
-            [$name, $src] = $parts;
+            if (!is_string($name->token)) {
+                throw new RuntimeException(sprintf('Expected a type name, got %s', Token::print($name->token)));
+            }
+            $colon = $tokens->next();
+            if ($colon?->token !== Token::Colon) {
+                throw new RuntimeException(sprintf('Expected a colon after the type name %s', $name->token));
+            }
             /**
              * @psalm-suppress InternalClass
              * @psalm-suppress InternalMethod
              */
-            $node = TypeParser::parseString($src);
-            if ($node instanceof SyntaxError) {
-                throw $node;
+            $node = TypeParser::parse($tokens);
+            if (!$node instanceof TypeNode) {
+                throw new RuntimeException(sprintf('Expected a type for %s', $name->token));
             }
-            $type = $types->resolve($node);
+            $type = (new Types($aliases))->resolve($node);
             if ($type instanceof TypeError) {
                 throw $type;
             }
-            $aliases[trim($name)] = $type;
-            $types = new Types($aliases);
-            $lines = explode("\n", $src);
-            array_splice($lines, 0, $node->location->endLine);
-            $src = implode("\n", $lines);
+            $aliases[$name->token] = $type;
         }
-        return $aliases;
     }
 }

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -285,7 +285,14 @@ final class ExpressionParserTest extends TestCase
         // === and > are non-associative, so a chain of them is a syntax error rather than a confusing type error.
         yield 'chained ===' => ['a:int === b:int === c:int', 'Unexpected ==='];
         yield 'chained >' => ['a:int > b:int > c:int', 'Unexpected >'];
+        // Whatever follows a complete expression is a mistake, not something to drop: silently returning the expression
+        // parsed so far turns a typo or an operator we don't have into a valid expression with a surprising value.
         yield 'trailing literal' => ['1 2', 'Unexpected 2'];
+        yield 'trailing literal after a complete subtraction' => ['1 - 1 999', 'Unexpected 999'];
+        yield 'trailing string literal' => ['"a" "b"', 'Unexpected "b"'];
+        yield 'trailing keyword' => ['true false', 'Unexpected identifier false'];
+        // `<` is not an operator, so this is a literal followed by junk rather than a comparison.
+        yield 'less than' => ['42 < 23', 'Unexpected <'];
         yield 'trailing operator' => ['a:int -', 'Expected expression, got end of input'];
         yield 'missing comma between list items' => ['[1 2]', 'Expected ], got 2'];
         yield 'missing comma between function arguments' => ['foo:string.substr(0 3)', 'Expected ), got 3'];

--- a/tests/unit/Parser/TypeParserTest.php
+++ b/tests/unit/Parser/TypeParserTest.php
@@ -13,6 +13,7 @@ use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
 use function explode;
 use function implode;
 use function preg_match;
@@ -204,6 +205,17 @@ final class TypeParserTest extends TestCase
         ];
     }
 
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function declarationErrorCases(): iterable
+    {
+        yield 'Name is not an identifier' => ['42: int', 'Expected type name, got 42'];
+        yield 'Missing colon after name' => ['Foo int', 'Expected :, got int'];
+        yield 'End of input after colon' => ['Foo:', 'Expected a type for Foo, got end of input'];
+        yield 'Non-type token after colon' => ['Foo: ->', 'Expected a type for Foo, got ->'];
+    }
+
     #[DataProvider('syntaxErrorCases')]
     public function testSyntaxErrors(string $type, string $expectedMessage): void
     {
@@ -257,5 +269,49 @@ final class TypeParserTest extends TestCase
 
         self::assertInstanceOf(Type::class, $actual);
         self::assertTrue($actual->equals($expected));
+    }
+
+    public function testParseDeclarationsReadsBackToBackTypesOffOneStream(): void
+    {
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
+        $declarations = TypeParser::parseDeclarations(
+            <<<'AUSDRUCK'
+                Item: {
+                    tags: list<string>,
+                }
+                Bag: {
+                    items: list<Item>,
+                }
+                AUSDRUCK,
+        );
+
+        self::assertSame(['Item', 'Bag'], array_keys($declarations));
+        self::assertSame('{ tags: list<string> }', (string)$declarations['Item']);
+        self::assertSame('{ items: list<Item> }', (string)$declarations['Bag']);
+    }
+
+    public function testParseDeclarationsAcceptsEmptyInput(): void
+    {
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
+        self::assertSame([], TypeParser::parseDeclarations('   '));
+    }
+
+    #[DataProvider('declarationErrorCases')]
+    public function testParseDeclarationsRejectsMalformedInput(string $src, string $expectedMessage): void
+    {
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        /**
+         * @psalm-suppress InternalClass
+         * @psalm-suppress InternalMethod
+         */
+        TypeParser::parseDeclarations($src);
     }
 }

--- a/tests/unit/Parser/TypeParserTest.php
+++ b/tests/unit/Parser/TypeParserTest.php
@@ -91,6 +91,19 @@ final class TypeParserTest extends TestCase
             '{name: string age: int}',
             'Expected }, got age',
         ];
+        // A type string is a whole type, so anything after the first complete one is an error rather than ignored.
+        yield 'Trailing identifier' => [
+            'int foo',
+            'Unexpected identifier foo',
+        ];
+        yield 'Trailing identifier after a generic type' => [
+            'list<int> bar',
+            'Unexpected identifier bar',
+        ];
+        yield 'Trailing literal' => [
+            'string 42',
+            'Unexpected 42',
+        ];
     }
 
     /**


### PR DESCRIPTION
`parse()` stopped at the first complete expression and dropped whatever followed, so `42 < 23` — a comparison the language doesn't have, because `<` is not an operator — quietly evaluated to `42`, and `1 - 1 999` to `999`.

`parseComplete()` already rejects a trailing token: it fell out of the precedence cascade (#56), which needed a top level to hang the cascade off anyway. Only `1 2` was pinned, though, so this pins the cases from the issue too. `42 < 23` is the one worth having — it's the reason the missing `<` operator (#49) was invisible rather than a syntax error.

The same hole was still open one door down, in `TypeParser::parseString()`, where `int foo` parsed as `int`. Unlike `TypeParser::parse()`, which reads one type off a stream the expression parser keeps using afterwards, nothing comes after a type string, so a leftover token is an error rather than the caller's business.

`E2eCase` leaned on that truncation: it read a Types section's `Name: <type>` declarations by handing `parseString()` the entire rest of the section and splicing off the consumed lines by line count. It now reads them off a single token stream, which is what the type parser wants anyway — it stops when the type is complete and leaves the stream on the next declaration's name.

Both entry points name the offending token the same way, through `SyntaxError::unexpectedToken()`.

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)