### PR TITLE
Unify built-in functions into a single source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The target can be any expression. It will be passed as the first argument to the
 |------------|------------------------------------------------------------------------|--------------------------------------------------|
 | `count`    | Returns the number of elements in a list                               | `foo:list<string>.count:int()`                   |
 | `contains` | Returns whether a list contains a value                                | `foo:list<string>.contains:bool("bar")`          |
+| `filter`   | Returns a new list of the elements matching a [predicate](#lambdas)    | `foo:list<int>.filter:list<int>(\|i\| i:int > 2)`|
 | `head`     | Returns the first element of a list as an `Option`                     | `foo:list<string>.head:Option<string>()`         |
 | `isSome`   | Takes an Option and returns whether it is `Some`                       | `foo:Option<int>.isSome:bool()`                  |
 | `map`      | Returns a new list with the results of applying a [function](#lambdas) | `foo:list<int>.map:list<int>(\|i\| i:int - 2)`   |
@@ -147,6 +148,7 @@ The target can be any expression. It will be passed as the first argument to the
 | `tail`     | Returns all elements of a list except the first                        | `foo:list<string>.tail:list<string>()`           |
 | `take`     | Returns the first n elements of a list                                 | `foo:list<string>.take:list<string>(5)`          |
 | `unique`   | Returns a list with duplicate elements removed                         | `foo:list<string>.unique:list<string>()`         |
+| `unwrap`   | Returns the value contained in an `Option`                             | `foo:Option<int>.unwrap:int()`                   |
 
 #### Custom Functions
 

--- a/src/BuiltinFunctions.php
+++ b/src/BuiltinFunctions.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Countable;
+
+use function array_is_list;
+use function array_map;
+use function array_slice;
+use function array_values;
+use function count;
+use function in_array;
+use function substr;
+
+/**
+ * The single source of truth for the library's built-in functions.
+ *
+ * Every built-in has an implementation, used at evaluation time by {@see Scope}. Where the signature can be expressed
+ * without generics, it also has a declared {@see Type}, used at parse time by {@see Parser\Declarations};
+ * the rest (`filter`, `head`, `map`, `tail`, `unwrap`) declare `null` and rely on the parser's inline-return-type escape
+ * hatch until generics land.
+ *
+ * Keeping the name, implementation and signature together here prevents the three from drifting apart.
+ *
+ * @internal
+ */
+final class BuiltinFunctions
+{
+    /**
+     * @return array<string, array{impl: callable, type: Type|null}>
+     */
+    public static function all(): array
+    {
+        return [
+            'contains' => ['impl' => self::contains(...), 'type' => Type::func(Type::bool(), [Type::listOf(Type::any()), Type::any()])],
+            'count' => ['impl' => self::count(...), 'type' => Type::func(Type::int(), [Type::listOf(Type::any())])],
+            'filter' => ['impl' => self::filter(...), 'type' => null],
+            'head' => ['impl' => self::head(...), 'type' => null],
+            'isSome' => ['impl' => self::isSome(...), 'type' => Type::func(Type::bool(), [Type::option(Type::any())])],
+            'map' => ['impl' => self::map(...), 'type' => null],
+            'some' => ['impl' => self::some(...), 'type' => Type::func(Type::bool(), [Type::listOf(Type::any()), Type::func(Type::bool(), [Type::any()])])],
+            'substr' => ['impl' => substr(...), 'type' => Type::func(Type::string(), [Type::string(), Type::int(), Type::int()])],
+            'tail' => ['impl' => self::tail(...), 'type' => null],
+            'take' => ['impl' => self::take(...), 'type' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any()), Type::int()])],
+            'unique' => ['impl' => self::unique(...), 'type' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any())])],
+            'unwrap' => ['impl' => self::identity(...), 'type' => null],
+        ];
+    }
+
+    /**
+     * @template K of array-key
+     * @template From
+     * @template To
+     * @param array<K, From> $items
+     * @param callable(From): To $f
+     * @return array<K, To>
+     */
+    private static function map(array $items, callable $f): array
+    {
+        return array_map($f, $items);
+    }
+
+    /**
+     * @template T
+     * @param array<array-key, T> $haystack
+     * @param callable(T): bool $predicate
+     */
+    private static function some(array $haystack, callable $predicate): bool
+    {
+        foreach ($haystack as $item) {
+            if (!$predicate($item)) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @template T
+     * @param list<T> $items
+     * @return list<T>
+     */
+    private static function tail(array $items): array
+    {
+        return array_slice($items, 1);
+    }
+
+    /**
+     * @template T
+     * @param array<array-key, T> $haystack
+     * @param T $needle
+     */
+    private static function contains(array $haystack, mixed $needle): bool
+    {
+        foreach ($haystack as $item) {
+            if ($item !== $needle) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param Countable|array<array-key, mixed> $items
+     */
+    private static function count(Countable|array $items): int
+    {
+        return count($items);
+    }
+
+    /**
+     * @template K of array-key
+     * @template V
+     * @param array<K, V> $items
+     * @param callable(V): bool $predicate
+     * @return ($items is list<K> ? list<K> : array<K, V>)
+     */
+    private static function filter(array $items, callable $predicate): array
+    {
+        $out = [];
+        foreach ($items as $key => $item) {
+            if (!$predicate($item)) {
+                continue;
+            }
+            $out[$key] = $item;
+        }
+        return array_is_list($items) ? array_values($out) : $out;
+    }
+
+    /**
+     * @template T
+     * @param list<T> $items
+     * @return T | null
+     */
+    private static function head(array $items): mixed
+    {
+        return $items[0] ?? null;
+    }
+
+    /**
+     * @template U
+     * @param U | null $option
+     * @return ($option is null ? false : true)
+     */
+    private static function isSome(mixed $option): bool
+    {
+        return $option !== null;
+    }
+
+    /**
+     * @template T
+     * @param list<T> $items
+     * @return list<T>
+     */
+    private static function take(array $items, int $n): array
+    {
+        return array_slice($items, 0, $n);
+    }
+
+    /**
+     * @template T
+     * @param list<T> $items
+     * @return list<T>
+     */
+    private static function unique(array $items): array
+    {
+        $unique = [];
+        foreach ($items as $item) {
+            if (in_array($item, $unique, true)) {
+                continue;
+            }
+            $unique[] = $item;
+        }
+        return $unique;
+    }
+
+    /**
+     * @template T
+     * @param T $value
+     * @return T
+     */
+    private static function identity(mixed $value): mixed
+    {
+        return $value;
+    }
+}

--- a/src/BuiltinFunctions.php
+++ b/src/BuiltinFunctions.php
@@ -17,21 +17,51 @@ use function substr;
 /**
  * The single source of truth for the library's built-in functions.
  *
- * Every built-in has an implementation, used at evaluation time by {@see Scope}. Where the signature can be expressed
- * without generics, it also has a declared {@see Type}, used at parse time by {@see Parser\Declarations};
- * the rest (`filter`, `head`, `map`, `tail`, `unwrap`) declare `null` and rely on the parser's inline-return-type escape
- * hatch until generics land.
+ * Every built-in has an implementation, exposed to evaluation ({@see Scope}) via {@see self::implementations()}. Where
+ * the signature can be expressed without generics, it also has a declared {@see Type}, exposed to parsing
+ * ({@see Parser\Declarations}) via {@see self::types()}; the rest (`filter`, `head`, `map`, `tail`, `unwrap`) declare
+ * `null` and rely on the parser's inline-return-type escape hatch until generics land.
  *
- * Keeping the name, implementation and signature together here prevents the three from drifting apart.
+ * Keeping the name, implementation and signature together in one table here prevents the three from drifting apart.
  *
  * @internal
  */
 final class BuiltinFunctions
 {
     /**
+     * The implementation of every built-in, keyed by name, for use at evaluation time.
+     *
+     * @return array<string, callable>
+     */
+    public static function implementations(): array
+    {
+        return array_map(static fn(array $fn): callable => $fn['impl'], self::definitions());
+    }
+
+    /**
+     * The declared signatures of the built-ins that can be expressed without generics, keyed by name, for use at parse
+     * time. The generic ones (`filter`, `head`, `map`, `tail`, `unwrap`) are omitted.
+     *
+     * @return array<string, Type>
+     */
+    public static function types(): array
+    {
+        $types = [];
+        foreach (self::definitions() as $name => $fn) {
+            if ($fn['type'] === null) {
+                continue;
+            }
+            $types[$name] = $fn['type'];
+        }
+        return $types;
+    }
+
+    /**
+     * The single source of truth: name, implementation and (where expressible) declared signature, together.
+     *
      * @return array<string, array{impl: callable, type: Type|null}>
      */
-    public static function all(): array
+    private static function definitions(): array
     {
         return [
             'contains' => ['impl' => self::contains(...), 'type' => Type::func(Type::bool(), [Type::listOf(Type::any()), Type::any()])],

--- a/src/Parser/Declarations.php
+++ b/src/Parser/Declarations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck\Parser;
 
+use Eventjet\Ausdruck\BuiltinFunctions;
 use Eventjet\Ausdruck\Type;
 use InvalidArgumentException;
 
@@ -24,21 +25,15 @@ final class Declarations
         public readonly array $variables = [],
         array $functions = [],
     ) {
-        $fns = [
-            'contains' => Type::func(Type::bool(), [Type::listOf(Type::any()), Type::any()]),
-            'count' => Type::func(Type::int(), [Type::listOf(Type::any())]),
-            // Can't declare filter until we have generics
-            // 'filter' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any()), Type::func(Type::bool(), [Type::any()])]),
-            'isSome' => Type::func(Type::bool(), [Type::option(Type::any())]),
-            // Can't declare map until we have generics
-            // 'map' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any()), Type::func(Type::any(), [Type::any()])]),
-            'some' => Type::func(Type::bool(), [Type::listOf(Type::any()), Type::func(Type::bool(), [Type::any()])]),
-            'substr' => Type::func(Type::string(), [Type::string(), Type::int(), Type::int()]),
-            'take' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any()), Type::int()]),
-            'unique' => Type::func(Type::listOf(Type::any()), [Type::listOf(Type::any())]),
-            // Can't declare unwrap until we have generics
-            // 'unwrap' => Type::func(Type::some(Type::any()), [Type::option(Type::any())]),
-        ];
+        $fns = [];
+        foreach (BuiltinFunctions::all() as $name => $fn) {
+            // filter, head, map, tail and unwrap can't be declared until we have generics; they carry a null type and
+            // rely on the parser's inline-return-type escape hatch instead.
+            if ($fn['type'] === null) {
+                continue;
+            }
+            $fns[$name] = $fn['type'];
+        }
         foreach ($functions as $name => $type) {
             if (array_key_exists($name, $fns)) {
                 throw new InvalidArgumentException(sprintf('Can\'t override built-in function %s', $name));

--- a/src/Parser/Declarations.php
+++ b/src/Parser/Declarations.php
@@ -25,15 +25,7 @@ final class Declarations
         public readonly array $variables = [],
         array $functions = [],
     ) {
-        $fns = [];
-        foreach (BuiltinFunctions::all() as $name => $fn) {
-            // filter, head, map, tail and unwrap can't be declared until we have generics; they carry a null type and
-            // rely on the parser's inline-return-type escape hatch instead.
-            if ($fn['type'] === null) {
-                continue;
-            }
-            $fns[$name] = $fn['type'];
-        }
+        $fns = BuiltinFunctions::types();
         foreach ($functions as $name => $type) {
             if (array_key_exists($name, $fns)) {
                 throw new InvalidArgumentException(sprintf('Can\'t override built-in function %s', $name));

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -36,9 +36,7 @@ final class Scope
      */
     public function __construct(private readonly array $vars = [], array $funcs = [], private readonly Scope|null $parent = null)
     {
-        $predefinedFuncs = $this->parent === null
-            ? array_map(static fn(array $fn): callable => $fn['impl'], BuiltinFunctions::all())
-            : [];
+        $predefinedFuncs = $this->parent === null ? BuiltinFunctions::implementations() : [];
         $shadowed = array_intersect(array_keys($predefinedFuncs), array_keys($funcs));
         if ($shadowed !== []) {
             throw new LogicException(sprintf('Can\'t shadow predefined functions: %s', implode(', ', $shadowed)));

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Countable;
 use LogicException;
 
 use function array_intersect;
-use function array_is_list;
 use function array_keys;
 use function array_map;
-use function array_slice;
-use function array_values;
-use function count;
 use function get_debug_type;
 use function get_object_vars;
 use function implode;
-use function in_array;
 use function is_bool;
 use function is_int;
 use function is_object;
@@ -42,20 +36,9 @@ final class Scope
      */
     public function __construct(private readonly array $vars = [], array $funcs = [], private readonly Scope|null $parent = null)
     {
-        $predefinedFuncs = $this->parent === null ? [
-            'contains' => self::contains(...),
-            'count' => self::count(...),
-            'filter' => self::filter(...),
-            'head' => self::head(...),
-            'isSome' => self::isSome(...),
-            'map' => self::map(...),
-            'some' => self::some(...),
-            'substr' => substr(...),
-            'tail' => self::tail(...),
-            'take' => self::take(...),
-            'unique' => self::unique(...),
-            'unwrap' => self::identity(...),
-        ] : [];
+        $predefinedFuncs = $this->parent === null
+            ? array_map(static fn(array $fn): callable => $fn['impl'], BuiltinFunctions::all())
+            : [];
         $shadowed = array_intersect(array_keys($predefinedFuncs), array_keys($funcs));
         if ($shadowed !== []) {
             throw new LogicException(sprintf('Can\'t shadow predefined functions: %s', implode(', ', $shadowed)));
@@ -76,145 +59,6 @@ final class Scope
             }
             throw new LogicException(sprintf('Can\'t shadow function "%s" in ancestor scope', $name));
         }
-    }
-
-    /**
-     * @template K of array-key
-     * @template From
-     * @template To
-     * @param array<K, From> $items
-     * @param callable(From): To $f
-     * @return array<K, To>
-     */
-    private static function map(array $items, callable $f): array
-    {
-        return array_map($f, $items);
-    }
-
-    /**
-     * @template T
-     * @param array<array-key, T> $haystack
-     * @param callable(T): bool $predicate
-     */
-    private static function some(array $haystack, callable $predicate): bool
-    {
-        foreach ($haystack as $item) {
-            if (!$predicate($item)) {
-                continue;
-            }
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * @template T
-     * @param list<T> $items
-     * @return list<T>
-     */
-    private static function tail(array $items): array
-    {
-        return array_slice($items, 1);
-    }
-
-    /**
-     * @template T
-     * @param array<array-key, T> $haystack
-     * @param T $needle
-     */
-    private static function contains(array $haystack, mixed $needle): bool
-    {
-        foreach ($haystack as $item) {
-            if ($item !== $needle) {
-                continue;
-            }
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * @param Countable|array<array-key, mixed> $items
-     */
-    private static function count(Countable|array $items): int
-    {
-        return count($items);
-    }
-
-    /**
-     * @template K of array-key
-     * @template V
-     * @param array<K, V> $items
-     * @param callable(V): bool $predicate
-     * @return ($items is list<K> ? list<K> : array<K, V>)
-     */
-    private static function filter(array $items, callable $predicate): array
-    {
-        $out = [];
-        foreach ($items as $key => $item) {
-            if (!$predicate($item)) {
-                continue;
-            }
-            $out[$key] = $item;
-        }
-        return array_is_list($items) ? array_values($out) : $out;
-    }
-
-    /**
-     * @template T
-     * @param list<T> $items
-     * @return T | null
-     */
-    private static function head(array $items): mixed
-    {
-        return $items[0] ?? null;
-    }
-
-    /**
-     * @template U
-     * @param U | null $option
-     * @return ($option is null ? false : true)
-     */
-    private static function isSome(mixed $option): bool
-    {
-        return $option !== null;
-    }
-
-    /**
-     * @template T
-     * @param list<T> $items
-     * @return list<T>
-     */
-    private static function take(array $items, int $n): array
-    {
-        return array_slice($items, 0, $n);
-    }
-
-    /**
-     * @template T
-     * @param list<T> $items
-     * @return list<T>
-     */
-    private static function unique(array $items): array
-    {
-        $unique = [];
-        foreach ($items as $item) {
-            if (in_array($item, $unique, true)) {
-                continue;
-            }
-            $unique[] = $item;
-        }
-        return $unique;
-    }
-
-    /**
-     * @template T
-     * @param T $value
-     * @return T
-     */
-    private static function identity(mixed $value): mixed
-    {
-        return $value;
     }
 
     /**

--- a/tests/unit/BuiltinFunctionsTest.php
+++ b/tests/unit/BuiltinFunctionsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Test\Unit;
+
+use Eventjet\Ausdruck\BuiltinFunctions;
+use Eventjet\Ausdruck\Parser\Declarations;
+use Eventjet\Ausdruck\Scope;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function array_keys;
+use function explode;
+use function file_get_contents;
+use function preg_match;
+use function sort;
+use function sprintf;
+use function str_starts_with;
+use function trim;
+
+/**
+ * Guards the single source of truth for built-in functions against drift: {@see Scope} (implementations),
+ * {@see Declarations} (parse-time signatures) and the README table must all agree with {@see BuiltinFunctions::all()}.
+ */
+final class BuiltinFunctionsTest extends TestCase
+{
+    /**
+     * Extracts the function names from the first column of the "Built-In Functions" table in the README.
+     *
+     * @return list<string>
+     */
+    private static function readmeBuiltinNames(): array
+    {
+        $readme = file_get_contents(__DIR__ . '/../../README.md');
+        if ($readme === false) {
+            throw new RuntimeException('Could not read README.md');
+        }
+        $names = [];
+        $inSection = false;
+        foreach (explode("\n", $readme) as $line) {
+            if (str_starts_with($line, '#### ')) {
+                $inSection = trim($line) === '#### Built-In Functions';
+                continue;
+            }
+            if (!$inSection || !str_starts_with($line, '|')) {
+                continue;
+            }
+            $firstCell = trim(explode('|', $line)[1]);
+            // Skip the header row and the |---| separator row.
+            if ($firstCell === 'Function' || preg_match('/^-+$/', $firstCell) === 1) {
+                continue;
+            }
+            $names[] = trim($firstCell, '`');
+        }
+        return $names;
+    }
+
+    public function testEveryBuiltinResolvesToACallableInARootScope(): void
+    {
+        $scope = new Scope();
+
+        foreach (array_keys(BuiltinFunctions::all()) as $name) {
+            self::assertNotNull($scope->func($name), sprintf('Built-in "%s" has no implementation in Scope', $name));
+        }
+    }
+
+    public function testDeclarationsExposeExactlyTheBuiltinsWithADeclaredType(): void
+    {
+        $expected = [];
+        foreach (BuiltinFunctions::all() as $name => $fn) {
+            if ($fn['type'] === null) {
+                continue;
+            }
+            $expected[] = $name;
+        }
+        sort($expected);
+
+        $declared = array_keys((new Declarations())->functions);
+        sort($declared);
+
+        self::assertSame($expected, $declared);
+    }
+
+    public function testReadmeDocumentsExactlyTheBuiltinFunctions(): void
+    {
+        $documented = self::readmeBuiltinNames();
+        sort($documented);
+
+        $expected = array_keys(BuiltinFunctions::all());
+        sort($expected);
+
+        self::assertSame($expected, $documented, 'The README built-in table has drifted from BuiltinFunctions::all()');
+    }
+}

--- a/tests/unit/BuiltinFunctionsTest.php
+++ b/tests/unit/BuiltinFunctionsTest.php
@@ -21,7 +21,7 @@ use function trim;
 
 /**
  * Guards the single source of truth for built-in functions against drift: {@see Scope} (implementations),
- * {@see Declarations} (parse-time signatures) and the README table must all agree with {@see BuiltinFunctions::all()}.
+ * {@see Declarations} (parse-time signatures) and the README table must all agree with {@see BuiltinFunctions}.
  */
 final class BuiltinFunctionsTest extends TestCase
 {
@@ -60,20 +60,14 @@ final class BuiltinFunctionsTest extends TestCase
     {
         $scope = new Scope();
 
-        foreach (array_keys(BuiltinFunctions::all()) as $name) {
+        foreach (array_keys(BuiltinFunctions::implementations()) as $name) {
             self::assertNotNull($scope->func($name), sprintf('Built-in "%s" has no implementation in Scope', $name));
         }
     }
 
     public function testDeclarationsExposeExactlyTheBuiltinsWithADeclaredType(): void
     {
-        $expected = [];
-        foreach (BuiltinFunctions::all() as $name => $fn) {
-            if ($fn['type'] === null) {
-                continue;
-            }
-            $expected[] = $name;
-        }
+        $expected = array_keys(BuiltinFunctions::types());
         sort($expected);
 
         $declared = array_keys((new Declarations())->functions);
@@ -87,9 +81,9 @@ final class BuiltinFunctionsTest extends TestCase
         $documented = self::readmeBuiltinNames();
         sort($documented);
 
-        $expected = array_keys(BuiltinFunctions::all());
+        $expected = array_keys(BuiltinFunctions::implementations());
         sort($expected);
 
-        self::assertSame($expected, $documented, 'The README built-in table has drifted from BuiltinFunctions::all()');
+        self::assertSame($expected, $documented, 'The README built-in table has drifted from the built-in functions');
     }
 }


### PR DESCRIPTION
## What

Unifies the library's built-in function list into a single source of truth so the three places that describe it can no longer drift apart.

Before, the set was duplicated across:

- `Parser\Declarations` — **7** parse-time type signatures
- `Scope` — **12** eval-time implementations
- `README.md` — **10** documented functions

Nothing kept them in sync.

## How

- New `@internal` `Eventjet\Ausdruck\BuiltinFunctions`. Its `all()` returns one entry per built-in — `['impl' => callable, 'type' => Type|null]` — with the name declared exactly once.
- `Scope` maps `all()` to its predefined implementations. The 11 implementation methods moved out of `Scope` verbatim (docblocks/generics intact).
- `Parser\Declarations` takes the parse-time signatures from the entries whose `type` isn't `null`. The 5 that can't be typed without generics (`filter`, `head`, `map`, `tail`, `unwrap`) declare `null` and keep riding the parser's inline-return-type escape hatch, exactly as before.
- README now documents all 12 built-ins (adds `filter` and `unwrap`).
- New `BuiltinFunctionsTest` asserts that `Scope` resolves every built-in, that `Declarations` exposes exactly the typed subset, and that the README table matches `all()` — so future drift fails the build.

## Compatibility

No BC break. No public or protected signature changed — only private `Scope` methods were relocated — and `Declarations::functions` produces byte-identical contents (same keys, same order, same types).

## Scope

Groundwork for #47 (rejecting unknown functions at parse time), which stays blocked on generics. This PR does **not** change that behavior.

## Verification

Full `composer check` green: `check-deps`, `cs-check`, `psalm`, `phpstan`, `phpunit` (619 tests), and `infection` at 100% MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
