### PR TITLE
Support parentheses for grouping sub-expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,20 @@ As in most languages, `&&` binds tighter than `||`, so `a:bool && b:bool || c:bo
 `===` and `>` are non-associative: `a:int > b:int > c:int` is a syntax error rather than a comparison against the
 `bool` that the first comparison produces. Chain with `&&` instead.
 
-There are no grouping parentheses yet, so you can't override the precedence.
+#### Grouping
+
+Wrap a sub-expression in parentheses to override the precedence:
+
+```
+a:bool && (b:bool || c:bool)
+(a:int - b:int) - c:int
+(a:int > b:int) === c:bool
+(a:int - b:int).abs:int()
+```
+
+Parentheses only group; they add no node of their own. Redundant ones — a group the precedence would have produced
+anyway, like `(a:int - b:int) - c:int` — parse fine and simply disappear, so printing an expression back out adds a
+pair of parentheses exactly where one is needed to parse it back into the same expression, and nowhere else.
 
 Anywhere an expression is expected, it can be a whole one, not only at the top level. List items, struct field values,
 function arguments, and lambda bodies are all full expressions, so operators, calls, and field access are available in

--- a/src/And_.php
+++ b/src/And_.php
@@ -23,8 +23,8 @@ final class And_ extends Expression
     {
         return sprintf(
             '%s && %s',
-            Precedence::parenthesize($this->left, Precedence::AND),
-            Precedence::parenthesize($this->right, Precedence::COMPARISON),
+            Precedence::parenthesize($this->left, Precedence::And),
+            Precedence::parenthesize($this->right, Precedence::Comparison),
         );
     }
 

--- a/src/And_.php
+++ b/src/And_.php
@@ -21,7 +21,11 @@ final class And_ extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s && %s', $this->left, $this->right);
+        return sprintf(
+            '%s && %s',
+            Precedence::parenthesize($this->left, Precedence::AND),
+            Precedence::parenthesize($this->right, Precedence::COMPARISON),
+        );
     }
 
     /**

--- a/src/Call.php
+++ b/src/Call.php
@@ -57,7 +57,7 @@ final class Call extends Expression
     {
         return sprintf(
             '%s.%s:%s(%s)',
-            Precedence::parenthesize($this->target, Precedence::PRIMARY),
+            Precedence::parenthesizeTarget($this->target),
             $this->name,
             $this->type,
             implode(', ', $this->arguments),

--- a/src/Call.php
+++ b/src/Call.php
@@ -55,7 +55,13 @@ final class Call extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s.%s:%s(%s)', $this->target, $this->name, $this->type, implode(', ', $this->arguments));
+        return sprintf(
+            '%s.%s:%s(%s)',
+            Precedence::parenthesize($this->target, Precedence::PRIMARY),
+            $this->name,
+            $this->type,
+            implode(', ', $this->arguments),
+        );
     }
 
     #[Override]

--- a/src/Eq.php
+++ b/src/Eq.php
@@ -52,7 +52,11 @@ final class Eq extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s === %s', $this->left, $this->right);
+        return sprintf(
+            '%s === %s',
+            Precedence::parenthesize($this->left, Precedence::ADDITIVE),
+            Precedence::parenthesize($this->right, Precedence::ADDITIVE),
+        );
     }
 
     #[Override]

--- a/src/Eq.php
+++ b/src/Eq.php
@@ -54,8 +54,8 @@ final class Eq extends Expression
     {
         return sprintf(
             '%s === %s',
-            Precedence::parenthesize($this->left, Precedence::ADDITIVE),
-            Precedence::parenthesize($this->right, Precedence::ADDITIVE),
+            Precedence::parenthesize($this->left, Precedence::Additive),
+            Precedence::parenthesize($this->right, Precedence::Additive),
         );
     }
 

--- a/src/FieldAccess.php
+++ b/src/FieldAccess.php
@@ -30,7 +30,7 @@ final class FieldAccess extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s.%s', Precedence::parenthesize($this->struct, Precedence::PRIMARY), $this->field);
+        return sprintf('%s.%s', Precedence::parenthesizeTarget($this->struct), $this->field);
     }
 
     #[Override]

--- a/src/FieldAccess.php
+++ b/src/FieldAccess.php
@@ -30,7 +30,7 @@ final class FieldAccess extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s.%s', $this->struct, $this->field);
+        return sprintf('%s.%s', Precedence::parenthesize($this->struct, Precedence::PRIMARY), $this->field);
     }
 
     #[Override]

--- a/src/Gt.php
+++ b/src/Gt.php
@@ -23,8 +23,8 @@ final class Gt extends Expression
     {
         return sprintf(
             '%s > %s',
-            Precedence::parenthesize($this->left, Precedence::ADDITIVE),
-            Precedence::parenthesize($this->right, Precedence::ADDITIVE),
+            Precedence::parenthesize($this->left, Precedence::Additive),
+            Precedence::parenthesize($this->right, Precedence::Additive),
         );
     }
 

--- a/src/Gt.php
+++ b/src/Gt.php
@@ -21,7 +21,11 @@ final class Gt extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s > %s', $this->left, $this->right);
+        return sprintf(
+            '%s > %s',
+            Precedence::parenthesize($this->left, Precedence::ADDITIVE),
+            Precedence::parenthesize($this->right, Precedence::ADDITIVE),
+        );
     }
 
     #[Override]

--- a/src/Literal.php
+++ b/src/Literal.php
@@ -11,6 +11,8 @@ use function array_is_list;
 use function array_map;
 use function implode;
 use function is_array;
+use function is_float;
+use function is_int;
 use function is_null;
 use function is_string;
 use function sprintf;
@@ -57,6 +59,16 @@ final class Literal extends AbstractLiteral
     public function __toString(): string
     {
         return self::dumpValue($this->value);
+    }
+
+    /**
+     * A number prints as bare digits, so an immediately following `.` would be read as a decimal point rather than a
+     * field or method access. {@see Precedence::parenthesizeTarget()} wraps such a receiver in parentheses because of
+     * it.
+     */
+    public function isNumber(): bool
+    {
+        return is_int($this->value) || is_float($this->value);
     }
 
     #[Override]

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -23,7 +23,7 @@ final class Negative extends Expression
 
     public function __toString(): string
     {
-        return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::UNARY));
+        return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::Unary));
     }
 
     #[Override]

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -23,7 +23,7 @@ final class Negative extends Expression
 
     public function __toString(): string
     {
-        return sprintf('-%s', $this->expression);
+        return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::UNARY));
     }
 
     #[Override]

--- a/src/Or_.php
+++ b/src/Or_.php
@@ -21,7 +21,11 @@ final class Or_ extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s || %s', $this->left, $this->right);
+        return sprintf(
+            '%s || %s',
+            Precedence::parenthesize($this->left, Precedence::OR),
+            Precedence::parenthesize($this->right, Precedence::AND),
+        );
     }
 
     /**

--- a/src/Or_.php
+++ b/src/Or_.php
@@ -23,8 +23,8 @@ final class Or_ extends Expression
     {
         return sprintf(
             '%s || %s',
-            Precedence::parenthesize($this->left, Precedence::OR),
-            Precedence::parenthesize($this->right, Precedence::AND),
+            Precedence::parenthesize($this->left, Precedence::Or),
+            Precedence::parenthesize($this->right, Precedence::And),
         );
     }
 

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -222,7 +222,7 @@ final class ExpressionParser
             return $this->parseStructLiteral();
         }
         if ($token === Token::OpenParen) {
-            return $this->parenthesized();
+            return $this->group();
         }
         throw SyntaxError::create(
             sprintf('Expected expression, got %s', Token::print($token)),
@@ -238,7 +238,7 @@ final class ExpressionParser
      * surrounds it, and the tree it produces is the same one the grouped operators would build at the top level. Which
      * grouping overrode the default precedence is recovered by {@see Precedence}, not stored here.
      */
-    private function parenthesized(): Expression
+    private function group(): Expression
     {
         $this->expect(Token::OpenParen);
         $inner = $this->parseExpression();

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -25,8 +25,10 @@ use function str_split;
  *
  * Each level consumes only its own operators and delegates to the next tighter level for its operands. Precedence and
  * associativity are therefore expressed by the call graph, and a level never needs to know which operators sit above
- * it. Anywhere a full expression is expected—a lambda body, a call argument, a list item, a struct field value—call
- * {@see self::parseExpression()} rather than one of the levels, so that operators are allowed there too.
+ * it. Anywhere a full expression is expected—a lambda body, a call argument, a list item, a struct field value, a
+ * parenthesized group—call {@see self::parseExpression()} rather than one of the levels, so that operators are allowed
+ * there too. A parenthesized group is the one such place that is itself an operand: it re-enters the cascade at the
+ * top from {@see self::parsePrimary()}, its tightest level, which is what lets parentheses override precedence.
  *
  * @api
  */
@@ -219,10 +221,29 @@ final class ExpressionParser
         if ($token === Token::OpenBrace) {
             return $this->parseStructLiteral();
         }
+        if ($token === Token::OpenParen) {
+            return $this->parenthesized();
+        }
         throw SyntaxError::create(
             sprintf('Expected expression, got %s', Token::print($token)),
             $parsedToken->location(),
         );
+    }
+
+    /**
+     * (a:bool || b:bool) && c:bool
+     * ==================
+     *
+     * Grouping adds no node of its own: it starts the cascade over, so the group is a whole expression whatever
+     * surrounds it, and the tree it produces is the same one the grouped operators would build at the top level. Which
+     * grouping overrode the default precedence is recovered by {@see Precedence}, not stored here.
+     */
+    private function parenthesized(): Expression
+    {
+        $this->expect(Token::OpenParen);
+        $inner = $this->parseExpression();
+        $this->expect(Token::CloseParen);
+        return $inner;
     }
 
     /**

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -10,12 +10,12 @@ use function sprintf;
 
 /**
  * How tightly an expression binds, on the same scale as the precedence cascade in {@see ExpressionParser}: the tighter
- * an operator's level in that cascade, the higher its number here. The two have to agree, because this exists only to
- * undo what the cascade does when an expression is printed back out.
+ * an operator's level in that cascade, the higher its case's value here. The two have to agree, because this exists only
+ * to undo what the cascade does when an expression is printed back out.
  *
  * An operator prints each operand with {@see self::parenthesize()}, passing the level the parser reads that operand at:
  * {@see ExpressionParser::parseOr()} reads the right side of `||` by calling {@see ExpressionParser::parseAnd()}, so
- * `||` prints its right side at {@see self::AND}. An operand looser than the level it sits at is wrapped in
+ * `||` prints its right side at {@see self::And}. An operand looser than the level it sits at is wrapped in
  * parentheses, because printing it bare would let the surrounding operator capture one of its parts, and parsing the
  * result back would then give a different tree. An operand at least as tight needs no parentheses, so redundant ones —
  * the parentheses in `(a:int - b:int) - c:int`, which the left-associative `-` would have grouped that way anyway —
@@ -27,53 +27,75 @@ use function sprintf;
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class Precedence
+enum Precedence: int
 {
     /**
      * The loosest level, looser even than `||`: a lambda's body runs to the right until something outside stops it, so
      * `|x| x:bool` used as an operand always has to be wrapped—`(|x| x:bool).foo:bool()` would otherwise print as
      * `|x| x:bool.foo:bool()` and re-parse with the `.foo` swallowed into the body.
      */
-    public const LAMBDA = 0;
-    public const OR = 1;
-    public const AND = 2;
-    public const COMPARISON = 3;
-    public const ADDITIVE = 4;
-    public const UNARY = 5;
+    case Lambda = 0;
+    case Or = 1;
+    case And = 2;
+    case Comparison = 3;
+    case Additive = 4;
+    case Unary = 5;
     /**
      * Calls, field accesses and the atomic expressions (literals, variables, lists, structs) all share the tightest
      * level: none of them can have an operand stolen, so none is ever parenthesized as an operand. Lambdas look atomic
-     * but are not—see {@see self::LAMBDA}.
+     * but are not—see {@see self::Lambda}.
      */
-    public const PRIMARY = 6;
+    case Primary = 6;
 
     /**
-     * Prints $operand as it appears in an operand slot that the parser reads at $level, wrapping it in parentheses when
-     * it binds looser than $level and would otherwise be re-parsed into a different tree.
+     * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
+     * it binds looser than $slot and would otherwise be re-parsed into a different tree.
      */
-    public static function parenthesize(Expression $operand, int $level): string
+    public static function parenthesize(Expression $operand, self $slot): string
     {
-        return self::of($operand) < $level ? sprintf('(%s)', $operand) : (string)$operand;
+        return self::of($operand)->bindsLooserThan($slot) ? sprintf('(%s)', $operand) : (string)$operand;
+    }
+
+    /**
+     * Prints $target as it appears before a postfix `.`—the receiver of a call or field access. This is the
+     * {@see self::Primary} slot, so precedence alone would never wrap anything; a bare number literal is the one
+     * exception, and needs parentheses for a reason the precedence cascade doesn't model. `2.abs:int()` re-tokenizes
+     * the `.` as a decimal point, and `-2.abs:int()` lets the `.` bind tighter than the leading minus, so each
+     * re-parses into a different tree than the `(2).foo` / `(-2).foo` receiver it was printed from. The hazard is
+     * lexical, not a matter of binding, which is why it lives here rather than in {@see self::of()}.
+     */
+    public static function parenthesizeTarget(Expression $target): string
+    {
+        if ($target instanceof Literal && $target->isNumber()) {
+            return sprintf('(%s)', $target);
+        }
+        return self::parenthesize($target, self::Primary);
     }
 
     /**
      * Only the nodes that bind loosely enough to ever need wrapping are named; everything else is primary-tight. The
      * default is deliberately forgiving rather than a hard error: {@see Expression} is public API, so a consumer can
-     * add nodes this class has never heard of, and an unknown node is almost always atomic—the safe reading is to
-     * treat it as {@see self::PRIMARY} rather than reject it. A node whose text runs past its own operands, though —
+     * add nodes this enum has never heard of, and an unknown node is almost always atomic—the safe reading is to
+     * treat it as {@see self::Primary} rather than reject it. A node whose text runs past its own operands, though —
      * any operator, and every lambda — has to be listed here, or printing it as an operand would drop the parentheses
-     * it needs.
+     * it needs. (A number literal is the one primary-tight node that still needs wrapping in a slot; that's a lexical
+     * quirk of the postfix `.`, handled in {@see self::parenthesizeTarget()} rather than by a level of its own.)
      */
-    private static function of(Expression $expr): int
+    private static function of(Expression $expr): self
     {
         return match (true) {
-            $expr instanceof Lambda => self::LAMBDA,
-            $expr instanceof Or_ => self::OR,
-            $expr instanceof And_ => self::AND,
-            $expr instanceof Eq, $expr instanceof Gt => self::COMPARISON,
-            $expr instanceof Subtract => self::ADDITIVE,
-            $expr instanceof Negative => self::UNARY,
-            default => self::PRIMARY,
+            $expr instanceof Lambda => self::Lambda,
+            $expr instanceof Or_ => self::Or,
+            $expr instanceof And_ => self::And,
+            $expr instanceof Eq, $expr instanceof Gt => self::Comparison,
+            $expr instanceof Subtract => self::Additive,
+            $expr instanceof Negative => self::Unary,
+            default => self::Primary,
         };
+    }
+
+    private function bindsLooserThan(self $slot): bool
+    {
+        return $this->value < $slot->value;
     }
 }

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -29,14 +29,21 @@ use function sprintf;
  */
 final class Precedence
 {
+    /**
+     * The loosest level, looser even than `||`: a lambda's body runs to the right until something outside stops it, so
+     * `|x| x:bool` used as an operand always has to be wrapped—`(|x| x:bool).foo:bool()` would otherwise print as
+     * `|x| x:bool.foo:bool()` and re-parse with the `.foo` swallowed into the body.
+     */
+    public const LAMBDA = 0;
     public const OR = 1;
     public const AND = 2;
     public const COMPARISON = 3;
     public const ADDITIVE = 4;
     public const UNARY = 5;
     /**
-     * Calls, field accesses and the atomic expressions (literals, variables, lists, structs, lambdas) all share the
-     * tightest level: none of them can have an operand stolen, so none is ever parenthesized as an operand.
+     * Calls, field accesses and the atomic expressions (literals, variables, lists, structs) all share the tightest
+     * level: none of them can have an operand stolen, so none is ever parenthesized as an operand. Lambdas look atomic
+     * but are not—see {@see self::LAMBDA}.
      */
     public const PRIMARY = 6;
 
@@ -49,9 +56,18 @@ final class Precedence
         return self::of($operand) < $level ? sprintf('(%s)', $operand) : (string)$operand;
     }
 
+    /**
+     * Only the nodes that bind loosely enough to ever need wrapping are named; everything else is primary-tight. The
+     * default is deliberately forgiving rather than a hard error: {@see Expression} is public API, so a consumer can
+     * add nodes this class has never heard of, and an unknown node is almost always atomic—the safe reading is to
+     * treat it as {@see self::PRIMARY} rather than reject it. A node whose text runs past its own operands, though —
+     * any operator, and every lambda — has to be listed here, or printing it as an operand would drop the parentheses
+     * it needs.
+     */
     private static function of(Expression $expr): int
     {
         return match (true) {
+            $expr instanceof Lambda => self::LAMBDA,
             $expr instanceof Or_ => self::OR,
             $expr instanceof And_ => self::AND,
             $expr instanceof Eq, $expr instanceof Gt => self::COMPARISON,

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\ExpressionParser;
+
+use function sprintf;
+
+/**
+ * How tightly an expression binds, on the same scale as the precedence cascade in {@see ExpressionParser}: the tighter
+ * an operator's level in that cascade, the higher its number here. The two have to agree, because this exists only to
+ * undo what the cascade does when an expression is printed back out.
+ *
+ * An operator prints each operand with {@see self::parenthesize()}, passing the level the parser reads that operand at:
+ * {@see ExpressionParser::parseOr()} reads the right side of `||` by calling {@see ExpressionParser::parseAnd()}, so
+ * `||` prints its right side at {@see self::AND}. An operand looser than the level it sits at is wrapped in
+ * parentheses, because printing it bare would let the surrounding operator capture one of its parts, and parsing the
+ * result back would then give a different tree. An operand at least as tight needs no parentheses, so redundant ones —
+ * the parentheses in `(a:int - b:int) - c:int`, which the left-associative `-` would have grouped that way anyway —
+ * are dropped.
+ *
+ * The levels are not stored on the nodes: grouping leaves no trace in the tree, so the same tree always prints the same
+ * way regardless of whether it was built with parentheses, in the builder API, or by the parser.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Precedence
+{
+    public const OR = 1;
+    public const AND = 2;
+    public const COMPARISON = 3;
+    public const ADDITIVE = 4;
+    public const UNARY = 5;
+    /**
+     * Calls, field accesses and the atomic expressions (literals, variables, lists, structs, lambdas) all share the
+     * tightest level: none of them can have an operand stolen, so none is ever parenthesized as an operand.
+     */
+    public const PRIMARY = 6;
+
+    /**
+     * Prints $operand as it appears in an operand slot that the parser reads at $level, wrapping it in parentheses when
+     * it binds looser than $level and would otherwise be re-parsed into a different tree.
+     */
+    public static function parenthesize(Expression $operand, int $level): string
+    {
+        return self::of($operand) < $level ? sprintf('(%s)', $operand) : (string)$operand;
+    }
+
+    private static function of(Expression $expr): int
+    {
+        return match (true) {
+            $expr instanceof Or_ => self::OR,
+            $expr instanceof And_ => self::AND,
+            $expr instanceof Eq, $expr instanceof Gt => self::COMPARISON,
+            $expr instanceof Subtract => self::ADDITIVE,
+            $expr instanceof Negative => self::UNARY,
+            default => self::PRIMARY,
+        };
+    }
+}

--- a/src/Subtract.php
+++ b/src/Subtract.php
@@ -23,8 +23,8 @@ final class Subtract extends Expression
     {
         return sprintf(
             '%s - %s',
-            Precedence::parenthesize($this->minuend, Precedence::ADDITIVE),
-            Precedence::parenthesize($this->subtrahend, Precedence::UNARY),
+            Precedence::parenthesize($this->minuend, Precedence::Additive),
+            Precedence::parenthesize($this->subtrahend, Precedence::Unary),
         );
     }
 

--- a/src/Subtract.php
+++ b/src/Subtract.php
@@ -21,7 +21,11 @@ final class Subtract extends Expression
 
     public function __toString(): string
     {
-        return sprintf('%s - %s', $this->minuend, $this->subtrahend);
+        return sprintf(
+            '%s - %s',
+            Precedence::parenthesize($this->minuend, Precedence::ADDITIVE),
+            Precedence::parenthesize($this->subtrahend, Precedence::UNARY),
+        );
     }
 
     /**

--- a/tests/unit/EndToEndTest.php
+++ b/tests/unit/EndToEndTest.php
@@ -7,6 +7,7 @@ namespace Eventjet\Ausdruck\Test\Unit;
 use Eventjet\Ausdruck\Parser\Declarations;
 use Eventjet\Ausdruck\Parser\ExpressionParser;
 use Eventjet\Ausdruck\Scope;
+use Eventjet\Ausdruck\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -31,5 +32,24 @@ final class EndToEndTest extends TestCase
         $actual = $expression->evaluate(new Scope($case->input));
 
         self::assertEquals($case->expected, $actual);
+    }
+
+    /**
+     * A grouped lambda is a real, evaluable call target: `doCall` invokes its receiver, so
+     * `(|x| x:string).doCall:string("foo")` runs the lambda with "foo" and yields "foo". Without the group the
+     * `.doCall` would bind inside the body and describe a different expression, so printing the tree back out has to
+     * keep the parentheses—re-parsing the printed form has to land on the same tree and evaluate to the same value.
+     */
+    public function testGroupedLambdaIsAnEvaluableCallTargetThatSurvivesRoundTripping(): void
+    {
+        $doCall = Type::func(Type::string(), [Type::func(Type::string(), [Type::string()]), Type::string()]);
+        $declarations = new Declarations(functions: ['doCall' => $doCall]);
+        $scope = new Scope([], ['doCall' => static fn(callable $fn, string $arg): mixed => $fn($arg)]);
+
+        $expression = ExpressionParser::parse('(|x| x:string).doCall:string("foo")', $declarations);
+        $reparsed = ExpressionParser::parse((string)$expression, $declarations);
+
+        self::assertSame('foo', $expression->evaluate($scope));
+        self::assertSame('foo', $reparsed->evaluate($scope));
     }
 }

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -224,6 +224,20 @@ final class ExpressionParserTest extends TestCase
                 '(|x| x:bool).foo:bool()',
                 Expr::lambda(Expr::get('x', $b), ['x'])->call('foo', $b, []),
             ],
+            // A number literal is primary-tight, yet a method call on one still has to wrap it: `2.abs:int()` would
+            // read the `.` as a decimal point, and `-2.abs:int()` would bind the `.` tighter than the leading minus.
+            [
+                '(2).abs:int()',
+                Expr::literal(2)->call('abs', $i, []),
+            ],
+            [
+                '(-2).abs:int()',
+                Expr::literal(-2)->call('abs', $i, []),
+            ],
+            [
+                '(2.5).floor:int()',
+                Expr::literal(2.5)->call('floor', $i, []),
+            ],
         ];
         foreach ($cases as $case) {
             yield $case[0] => $case;

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -171,6 +171,53 @@ final class ExpressionParserTest extends TestCase
                     Span::char(1, 1),
                 ),
             ],
+            // Parentheses group without leaving a node of their own, so a grouped tree prints with exactly the
+            // parentheses needed to parse it back the same way: one per operand that would otherwise be captured by a
+            // tighter operator around it. There's a canonical case for each level of the cascade being forced to sit
+            // inside a looser one, which is the grouping that level's precedence would never produce on its own.
+            [
+                'a:bool && (b:bool || c:bool)',
+                Expr::and_(Expr::get('a', $b), Expr::or_(Expr::get('b', $b), Expr::get('c', $b))),
+            ],
+            [
+                '(a:bool || b:bool) && c:bool',
+                Expr::and_(Expr::or_(Expr::get('a', $b), Expr::get('b', $b)), Expr::get('c', $b)),
+            ],
+            [
+                'a:bool || (b:bool || c:bool)',
+                Expr::or_(Expr::get('a', $b), Expr::or_(Expr::get('b', $b), Expr::get('c', $b))),
+            ],
+            [
+                'a:bool && (b:bool && c:bool)',
+                Expr::and_(Expr::get('a', $b), Expr::and_(Expr::get('b', $b), Expr::get('c', $b))),
+            ],
+            [
+                'a:int - (b:int - c:int)',
+                Expr::subtract(Expr::get('a', $i), Expr::subtract(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
+                '-(a:int - b:int)',
+                Expr::negative(Expr::subtract(Expr::get('a', $i), Expr::get('b', $i))),
+            ],
+            // === and > are non-associative, so a parenthesized comparison is the only way one ends up inside another.
+            [
+                '(a:int === b:int) === c:bool',
+                Expr::eq(Expr::eq(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $b)),
+            ],
+            [
+                '(a:int > b:int) === c:bool',
+                Expr::eq(Expr::gt(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $b)),
+            ],
+            // A method can be called on a grouped expression, so the postfix dot has to parenthesize a target looser
+            // than a call's own — everything from a subtraction down to a negation.
+            [
+                '(a:int - b:int).abs:int()',
+                Expr::subtract(Expr::get('a', $i), Expr::get('b', $i))->call('abs', $i, []),
+            ],
+            [
+                '(-a:int).abs:int()',
+                Expr::negative(Expr::get('a', $i))->call('abs', $i, []),
+            ],
         ];
         foreach ($cases as $case) {
             yield $case[0] => $case;
@@ -218,6 +265,33 @@ final class ExpressionParserTest extends TestCase
             // Negating a number literal folds into a negative literal, so the fold survives being nested.
             ['[-2]', Expr::listLiteral([Expr::literal(-2)], Span::char(1, 1))],
             ['- -1', Expr::literal(1)],
+            // Parentheses that only restate the default grouping leave no trace: the tree is the one the operators
+            // would have built anyway, so it prints back without them. A single atom in parentheses is the same atom.
+            ['(a:bool)', Expr::get('a', Type::bool())],
+            ['((a:bool))', Expr::get('a', Type::bool())],
+            [
+                '(a:int - b:int) - c:int',
+                Expr::subtract(
+                    Expr::subtract(Expr::get('a', Type::int()), Expr::get('b', Type::int())),
+                    Expr::get('c', Type::int()),
+                ),
+            ],
+            [
+                '(a:bool && b:bool) || c:bool',
+                Expr::or_(
+                    Expr::and_(Expr::get('a', Type::bool()), Expr::get('b', Type::bool())),
+                    Expr::get('c', Type::bool()),
+                ),
+            ],
+            // The grouping the issue asks for: left-associative subtraction already means (a - 1) - 2, so the
+            // parentheses are redundant, but they now parse instead of being a syntax error.
+            [
+                '(a:int - 1) - 2',
+                Expr::subtract(
+                    Expr::subtract(Expr::get('a', Type::int()), Expr::literal(1)),
+                    Expr::literal(2),
+                ),
+            ],
         ];
         foreach ($cases as $case) {
             yield $case[0] => $case;
@@ -296,6 +370,13 @@ final class ExpressionParserTest extends TestCase
         yield 'trailing operator' => ['a:int -', 'Expected expression, got end of input'];
         yield 'missing comma between list items' => ['[1 2]', 'Expected ], got 2'];
         yield 'missing comma between function arguments' => ['foo:string.substr(0 3)', 'Expected ), got 3'];
+        // A group is a whole expression between the parentheses: empty ones have nothing to group, and an unclosed one
+        // is missing its ). A close paren with no group of its own to end is junk after a complete expression.
+        yield 'empty parentheses' => ['()', 'Expected expression, got )'];
+        yield 'unclosed parenthesis' => ['(a:bool', 'Expected ), got end of input'];
+        yield 'unclosed parenthesis around a subtraction' => ['(a:int - b:int', 'Expected ), got end of input'];
+        yield 'comma inside parentheses' => ['(a:bool, b:bool)', 'Expected ), got ,'];
+        yield 'unmatched close parenthesis' => ['(a:bool))', 'Unexpected )'];
     }
 
     /**
@@ -511,6 +592,16 @@ final class ExpressionParserTest extends TestCase
             [
                 'foo:bool && bar::bool',
                 '                =    ',
+            ],
+            // An empty group is blamed at the close paren, where the expression it should have held is missing. A
+            // surplus close paren is blamed at itself, the token with nothing left to close.
+            [
+                '()',
+                ' =',
+            ],
+            [
+                '(a:bool))',
+                '        =',
             ],
         ];
         foreach ($cases as [$expression, $location]) {

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -218,6 +218,12 @@ final class ExpressionParserTest extends TestCase
                 '(-a:int).abs:int()',
                 Expr::negative(Expr::get('a', $i))->call('abs', $i, []),
             ],
+            // A lambda is the loosest target of all: its body runs rightward, so without the parentheses the printed
+            // form would fold the `.foo` into the body and re-parse as a different tree.
+            [
+                '(|x| x:bool).foo:bool()',
+                Expr::lambda(Expr::get('x', $b), ['x'])->call('foo', $b, []),
+            ],
         ];
         foreach ($cases as $case) {
             yield $case[0] => $case;

--- a/tests/unit/cases/parentheses/and-groups-or.txt
+++ b/tests/unit/cases/parentheses/and-groups-or.txt
@@ -1,0 +1,9 @@
+a:bool && (b:bool || c:bool)
+-- Input --
+{
+  a: false,
+  b: false,
+  c: true,
+}
+-- Output --
+false

--- a/tests/unit/cases/parentheses/or-groups-and.txt
+++ b/tests/unit/cases/parentheses/or-groups-and.txt
@@ -1,0 +1,9 @@
+(a:bool || b:bool) && c:bool
+-- Input --
+{
+  a: true,
+  b: false,
+  c: false,
+}
+-- Output --
+false

--- a/tests/unit/cases/parentheses/subtract-groups-right.txt
+++ b/tests/unit/cases/parentheses/subtract-groups-right.txt
@@ -1,0 +1,9 @@
+a:int - (b:int - c:int)
+-- Input --
+{
+  a: 10,
+  b: 5,
+  c: 2,
+}
+-- Output --
+7


### PR DESCRIPTION
Closes #48.

`(` was only recognized as the start of a call's argument list, so sub-expressions couldn't be grouped and precedence couldn't be overridden. Some boolean expressions had no valid spelling at all — e.g. `(a && b) || c`.

## Parsing

`(...)` is now handled at the tightest level of the cascade (`parsePrimary`): it consumes the parens and re-enters via `parseExpression()`, so a group is a whole expression whatever surrounds it. **Grouping adds no AST node** — the tree is the one the operators would have built anyway. The tokenizer already emitted `(`/`)`, so it was unchanged.

## Round-tripping `__toString`

The parser can now build trees whose grouping overrides the default precedence (e.g. `a && (b || c)` → `And(a, Or(b, c))`). The old flat `__toString` would have printed that as `a && b || c`, which re-parses to a *different* tree. To keep `__toString` a faithful serialization, the new internal `Precedence` helper mirrors the parser cascade, and each operator wraps an operand in parentheses **exactly when it binds looser than its slot allows**:

- Required parens are reproduced: `a:bool && (b:bool || c:bool)`, `a:int - (b:int - c:int)`, `(-a:int).abs:int()`
- Redundant parens are dropped: `(a:int - b:int) - c:int` → `a:int - b:int - c:int`
- `parse(str(e))` equals `e` for every grouped tree

## Tests

- `parseCases`: one canonical case per cascade level forced inside a looser one (asserts both the parse and the printed form)
- `nonCanonicalParseCases`: redundant-paren inputs that get dropped, including the issue's `(a:int - 1) - 2`
- Syntax errors + two location assertions: `()`, unclosed, stray `)`, comma inside parens
- Three end-to-end evaluation cases proving grouping changes the *result* (e.g. `a && (b || c)` evaluates to `false` where the default grouping gives `true`)

README's "no grouping parentheses yet" is replaced with a **Grouping** section.

Infection passes at 100% MSI / 100% mutation coverage on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)