### PR TITLE
Stop an alias from borrowing the arguments of the type it names

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -70,9 +70,15 @@ final class Type implements Stringable
         return new self('map', [$keys, $values]);
     }
 
+    /**
+     * An alias is a name for one complete type, and takes no arguments of its own: the arguments of the type it stands
+     * for belong to that type, not to the name. Copying them here would make the alias print as `Bag<string>`, which
+     * reads back as arguments applied to Bag and is rejected. Everything that needs to see through the name calls
+     * {@see self::canonical()}.
+     */
     public static function alias(string $name, self $type): self
     {
-        return new self($name, $type->args, $type);
+        return new self($name, aliasFor: $type);
     }
 
     public static function any(): self
@@ -249,7 +255,7 @@ final class Type implements Stringable
         if ($self->name !== $other->name) {
             return false;
         }
-        if ($this->name === 'list') {
+        if ($self->name === 'list') {
             return $self->args[0]->isSubtypeOf($other->args[0]);
         }
         if ($self->name === 'Func') {
@@ -268,7 +274,7 @@ final class Type implements Stringable
                 }
             }
         }
-        if ($this->name === 'Struct') {
+        if ($self->name === 'Struct') {
             foreach ($other->fields as $name => $fieldType) {
                 if (!array_key_exists($name, $self->fields)) {
                     return false;
@@ -288,7 +294,7 @@ final class Type implements Stringable
      */
     public function returnType(): self
     {
-        return $this->args[0];
+        return $this->canonical()->args[0];
     }
 
     /**
@@ -334,7 +340,7 @@ final class Type implements Stringable
      */
     private function parameterTypes(): array
     {
-        return array_slice($this->args, 1);
+        return array_slice($this->canonical()->args, 1);
     }
 
     private function canonical(): self

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -11,6 +11,7 @@ use Eventjet\Ausdruck\Parser\ExpressionParser;
 use Eventjet\Ausdruck\Parser\Span;
 use Eventjet\Ausdruck\Parser\SyntaxError;
 use Eventjet\Ausdruck\Parser\TypeError;
+use Eventjet\Ausdruck\Parser\Types;
 use Eventjet\Ausdruck\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -768,6 +769,19 @@ final class ExpressionParserTest extends TestCase
         }
     }
 
+    /**
+     * @return iterable<string, array{string, array<string, Type>}>
+     */
+    public static function aliasRoundTripCases(): iterable
+    {
+        yield 'alias of a list' => ['foo:Bag', ['Bag' => Type::listOf(Type::string())]];
+        yield 'alias of a map' => ['foo:Lookup', ['Lookup' => Type::mapOf(Type::string(), Type::int())]];
+        yield 'alias of an option' => ['foo:Maybe', ['Maybe' => Type::option(Type::int())]];
+        yield 'alias of a scalar' => ['foo:Count', ['Count' => Type::int()]];
+        yield 'alias of a struct' => ['foo:Person', ['Person' => Type::struct(['name' => Type::string()])]];
+        yield 'alias inside a list' => ['foo:list<Bag>', ['Bag' => Type::listOf(Type::string())]];
+    }
+
     #[DataProvider('parseCases')]
     #[DataProvider('nonCanonicalParseCases')]
     public function testParse(string $str, Expression $expected): void
@@ -785,6 +799,25 @@ final class ExpressionParserTest extends TestCase
     public function testToString(string $expected, Expression $expr): void
     {
         self::assertSame($expected, (string)$expr);
+    }
+
+    /**
+     * Printing an expression has to spell a type the parser reads back. An alias of a parameterized type is the case
+     * that gets this wrong most easily: the type it stands for has arguments, the alias itself takes none, and printing
+     * the former under the latter's name produces `Bag<string>`, which no longer parses.
+     *
+     * @param array<string, Type> $aliases
+     */
+    #[DataProvider('aliasRoundTripCases')]
+    public function testAliasedTypesRoundTrip(string $expression, array $aliases): void
+    {
+        $declarations = new Declarations(types: new Types($aliases));
+        $expr = ExpressionParser::parse($expression, $declarations);
+
+        $reparsed = ExpressionParser::parse((string)$expr, $declarations);
+
+        self::assertSame($expression, (string)$expr);
+        self::assertTrue($expr->equals($reparsed), sprintf('%s does not equal %s', $expr, $reparsed));
     }
 
     #[DataProvider('invalidSyntaxExpressions')]

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -206,6 +206,57 @@ final class TypeTest extends TestCase
         self::assertTrue($bar->equals($foo));
     }
 
+    /**
+     * An alias is a name for one complete type, so it prints as that name and nothing else. Printing the arguments of
+     * the type it stands for would spell a type the parser rejects: `Bag<string>` reads as arguments applied to Bag,
+     * and an alias takes none.
+     */
+    public function testAliasOfAParameterizedTypePrintsAsItsNameAlone(): void
+    {
+        $alias = Type::alias('Bag', Type::listOf(Type::string()));
+
+        self::assertSame('Bag', (string)$alias);
+    }
+
+    /**
+     * Aliasing hides the layout a function type keeps its return and parameter types in, so the accessors have to look
+     * through the alias the same way subtyping and field lookup do.
+     */
+    public function testAliasOfAFunctionTypeKeepsItsSignatureReadable(): void
+    {
+        $alias = Type::alias('Callback', Type::func(Type::string(), [Type::int(), Type::bool()]));
+
+        self::assertTrue($alias->returnType()->equals(Type::string()));
+        self::assertTrue($alias->receiverType()?->equals(Type::int()) ?? false);
+        self::assertEquals([Type::bool()], $alias->argumentTypes());
+    }
+
+    /**
+     * A list's element type is compared by asking what kind of type the left side is, and an alias only answers that
+     * once it's been seen through. Asking the alias directly makes it none of the kinds that carry a check, so a list
+     * of one thing would pass as a list of another.
+     */
+    public function testAliasOfAListComparesItsElementType(): void
+    {
+        $ints = Type::alias('Ints', Type::listOf(Type::int()));
+
+        self::assertFalse($ints->isSubtypeOf(Type::listOf(Type::string())));
+        self::assertFalse($ints->isSubtypeOf(Type::alias('Strings', Type::listOf(Type::string()))));
+        self::assertTrue($ints->isSubtypeOf(Type::listOf(Type::int())));
+    }
+
+    /**
+     * The same for a struct: seeing through the alias is what leaves a struct to compare field by field.
+     */
+    public function testAliasOfAStructComparesItsFields(): void
+    {
+        $alias = Type::alias('Person', Type::struct(['name' => Type::string()]));
+
+        self::assertFalse($alias->isSubtypeOf(Type::struct(['name' => Type::int()])));
+        self::assertFalse($alias->isSubtypeOf(Type::struct(['age' => Type::int()])));
+        self::assertTrue($alias->isSubtypeOf(Type::struct(['name' => Type::string()])));
+    }
+
     #[DataProvider('failingAssertCases')]
     public function testFailingAssert(Type $type, mixed $value, string $expectedMessage): void
     {


### PR DESCRIPTION
Split from #62.

`Type::alias()` copied the aliased type's args onto the alias, so `Bag`, an alias for `list<string>`, carried `[string]` under its own name and printed as `Bag<string>`. That reads back as arguments applied to `Bag`, which an alias does not take, so printing an expression no longer spelled a type the parser could read.

An alias names one complete type; the arguments belong to that type, not to the name. Dropping them means everything that needs the underlying shape has to see through the name instead of reading it off the alias. `canonical()` already did that for equality and field lookup, but four places asked the alias directly:

- `returnType()` and `parameterTypes()` read args off the receiver, so an alias for a `fn` type reported no return type and no parameters.
- `isSubtypeOf()` canonicalizes both sides up front, but the branches carrying the list element check and the struct field check asked `$this->name` rather than `$self->name`. For an alias that is the alias's own name, so neither branch matched and control fell through to the trailing `return true` — the check never ran. `Ints`, an alias for `list<int>`, passed as a subtype of `list<string>`.

The whole suite passed either way, so nothing covered an alias on the left of a subtype check, or an aliased `fn` type's signature. Each new test fails without its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)