### PR TITLE
Fold the tokenizer's multi-character operators into one match

### DIFF
--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -10,7 +10,7 @@ use function is_numeric;
 use function ord;
 use function sprintf;
 use function str_contains;
-use function substr;
+use function str_split;
 
 /**
  * @internal
@@ -80,49 +80,29 @@ final class Tokenizer
                 yield new ParsedToken(self::string($chars, $line, $column), $startLine, $startCol);
                 continue;
             }
-            if ($char === '=') {
-                $startCol = $column;
-                $token = self::equals($chars, $line, $column);
-                yield new ParsedToken($token, $line, $startCol);
-                continue;
-            }
-            if ($char === '-') {
-                $startCol = $column;
-                yield new ParsedToken(self::minusOrArrow($chars, $column), $line, $startCol);
+            $startCol = $column;
+            $multiCharToken = match ($char) {
+                '=' => self::exact($chars, $line, $column, '===', Token::TripleEquals),
+                '&' => self::exact($chars, $line, $column, '&&', Token::And),
+                /**
+                 * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
+                 * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one.
+                 * If the sign were folded in here, whitespace would silently decide the meaning of `a -2`:
+                 * subtraction, or `a` followed by the literal -2.
+                 */
+                '-' => self::bareOrPair($chars, $column, '>', Token::Minus, Token::Arrow),
+                '|' => self::bareOrPair($chars, $column, '|', Token::Pipe, Token::Or),
+                default => null,
+            };
+            if ($multiCharToken !== null) {
+                yield new ParsedToken($multiCharToken, $line, $startCol);
                 continue;
             }
             if (is_numeric($char)) {
-                $startCol = $column;
                 yield new ParsedToken(self::number($chars, $column), $line, $startCol);
                 continue;
             }
-            if ($char === '|') {
-                $chars->next();
-                $char = $chars->peek();
-                if ($char === '|') {
-                    $chars->next();
-                    yield new ParsedToken(Token::Or, $line, $column);
-                    $column += 2;
-                } else {
-                    yield new ParsedToken(Token::Pipe, $line, $column);
-                    $column++;
-                }
-                continue;
-            }
-            if ($char === '&') {
-                $chars->next();
-                $char = $chars->peek();
-                if ($char === '&') {
-                    $chars->next();
-                    yield new ParsedToken(Token::And, $line, $column);
-                    $column += 2;
-                } else {
-                    throw SyntaxError::create('Unexpected character &', Span::char($line, $column));
-                }
-                continue;
-            }
             if (self::isIdentifierChar($char, first: true)) {
-                $startCol = $column;
                 yield new ParsedToken(self::identifier($chars, $line, $column), $line, $startCol);
                 continue;
             }
@@ -161,65 +141,56 @@ final class Tokenizer
     }
 
     /**
+     * Scans an operator that is the only token starting with its first character: `===` and `&&`. Once that first
+     * character is there, the whole sequence is required; anything short of it is an error naming the operator that
+     * was expected and underlining the characters that were actually read.
+     *
      * @param Peekable<string> $chars
      * @param positive-int $line
      * @param positive-int $column
+     * @param non-empty-string $sequence
      */
-    private static function equals(Peekable $chars, int $line, int &$column): Token
+    private static function exact(Peekable $chars, int $line, int &$column, string $sequence, Token $token): Token
     {
-        $chars->next();
-        $column++;
-        self::expect($chars, '==', $line, $column);
-        return Token::TripleEquals;
-    }
-
-    /**
-     * @param Peekable<string> $chars
-     * @param positive-int $line
-     * @param positive-int $column
-     */
-    private static function expect(Peekable $chars, string $expected, int $line, int &$column): void
-    {
-        $originalExpected = $expected;
-        while (true) {
-            if ($expected === '') {
-                return;
-            }
-            $actualChar = $chars->peek();
-            $expectedChar = $expected[0];
-            if ($actualChar !== $expectedChar) {
+        $startColumn = $column;
+        $read = '';
+        foreach (str_split($sequence) as $char) {
+            if ($chars->peek() !== $char) {
+                $endColumn = $column - 1;
+                // The main loop only dispatches here after peeking $sequence's first character, so that one matched.
+                assert($endColumn >= 1);
                 throw SyntaxError::create(
-                    $actualChar === null
-                        ? sprintf('Expected %s, got end of input', $originalExpected)
-                        : sprintf('Expected %s, got %s', $originalExpected, $actualChar),
-                    Span::char($line, $column),
+                    sprintf('Expected %s, got %s', $sequence, $read),
+                    new Span($line, $startColumn, $line, $endColumn),
                 );
             }
+            $read .= $char;
             $chars->next();
-            assert($actualChar !== "\n", 'We\'r never expecting newlines');
             $column++;
-            $expected = substr($expected, 1);
         }
+        return $token;
     }
 
     /**
-     * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
-     * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one. If the sign
-     * were folded in here, whitespace would silently decide the meaning of `a -2`: subtraction, or `a` followed by the
-     * literal -2.
+     * A character that means one token on its own and another when $second completes it: `-` and `->`, `|` and `||`.
+     * The pair always wins. For `->` it's the only reading that can be meant: no expression continues with a bare `-`
+     * followed by a `>`. For `||` it's a choice: the two bars could also be the empty parameter list of a lambda, so
+     * that list is written `| |`, and glued bars are the or they almost always are.
      *
      * @param Peekable<string> $chars
      * @param positive-int $column
+     * @param non-empty-string $second The character that, if it comes next, makes this $pair instead of $bare.
      */
-    private static function minusOrArrow(Peekable $chars, int &$column): Token
+    private static function bareOrPair(Peekable $chars, int &$column, string $second, Token $bare, Token $pair): Token
     {
         $chars->next();
         $column++;
-        if ($chars->peek() !== '>') {
-            return Token::Minus;
+        if ($chars->peek() !== $second) {
+            return $bare;
         }
         $chars->next();
-        return Token::Arrow;
+        $column++;
+        return $pair;
     }
 
     /**

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -325,11 +325,12 @@ final class ExpressionParserTest extends TestCase
     {
         yield 'string: missing closing quote' => ['"foo'];
         yield 'single pipe' => ['foo:bool | bar:bool'];
-        yield 'single equals' => ['foo:string = bar:string'];
-        yield 'double equals' => ['foo:string == bar:string'];
-        yield 'double length fat arrow' => ['foo:string ==> bar:string'];
+        // Equality is `===`; a `=` or `==` is blamed as the beginning of one, with the missing rest named.
+        yield 'single equals' => ['foo:string = bar:string', 'Expected ===, got ='];
+        yield 'double equals' => ['foo:string == bar:string', 'Expected ===, got =='];
+        yield 'double length fat arrow' => ['foo:string ==> bar:string', 'Expected ===, got =='];
         yield 'end after single pipe' => ['foo:bool |'];
-        yield 'end after single equals' => ['foo:bool =', 'Expected ==, got end of input'];
+        yield 'end after single equals' => ['foo:bool =', 'Expected ===, got ='];
         yield 'end after double equals' => ['foo:bool =='];
         yield 'close brace after triple equals' => ['foo:bool === )'];
         yield 'lambda: missing closing brace' => ['(foo, bar => foo:string'];
@@ -372,7 +373,7 @@ final class ExpressionParserTest extends TestCase
         yield 'end of string after struct field value' => ['{name: "John"'];
         yield 'missing value in struct literal' => ['{name: }'];
         yield 'missing comma between struct fields' => ['{name: "John" age: 42}'];
-        yield 'single ampersand' => ['foo:bool & bar:bool'];
+        yield 'single ampersand' => ['foo:bool & bar:bool', 'Expected &&, got &'];
         yield 'non-token, non-identifier symbol' => ['foo:bool € bar:bool'];
         yield 'identifier starting with a number' => ['42foo:bool', 'Unexpected identifier foo'];
         yield 'identifier starting with an underscore' => ['_foo:bool', 'Unexpected character _'];
@@ -609,6 +610,12 @@ final class ExpressionParserTest extends TestCase
                 'foo:bool & bar:bool',
                 '         =         ',
             ],
+            // An `=` that isn't the start of `===` is blamed with everything read after it: the operator that is
+            // actually there is underlined whole.
+            [
+                'foo:string == bar:string',
+                '           ==           ',
+            ],
             [
                 'foo:bool && bar::bool',
                 '                =    ',
@@ -622,6 +629,11 @@ final class ExpressionParserTest extends TestCase
             [
                 '(a:bool))',
                 '        =',
+            ],
+            // The `>` of an arrow is a column like any other: what follows it is blamed where it actually is.
+            [
+                'x:fn(int) -> int &',
+                '                 =',
             ],
         ];
         foreach ($cases as [$expression, $location]) {


### PR DESCRIPTION
Split from #62.

Four characters that start a token longer than themselves were handled by four separate `if`s after the single-character match, each with its own control flow: `=` called `equals()`, which called a general-purpose `expect()` loop; `-` called `minusOrArrow()`; `|` and `&` inlined their own peek-and-branch. The main loop had to be read in full to find out what a character does.

They now sit in one match beside the single-character one, dispatching to two helpers that name the two shapes actually present:

- `exact()` for an operator that is the only token starting with its first character (`===`, `&&`). Once that character is there the whole sequence is required.
- `bareOrPair()` for a character that means one token alone and another when a second completes it (`-`/`->`, `|`/`||`).

Three things change for the better:

- `expect()` reported the character it stopped at and pointed at a single column, so `foo:string == bar` said `Expected ==, got end of input` — the `==` it had already read went unmentioned and unmarked. `exact()` names the operator it wanted and underlines what was actually read: `Expected ===, got ==`.
- A lone `&` was a bare `Unexpected character &` written at the tokenizer's throw site. It now goes through `exact()` like every other incomplete operator: `Expected &&, got &`.
- `minusOrArrow()` consumed the `>` of an arrow **without counting the column**, so every span after an arrow was one column to the left of where it belonged. `bareOrPair()` counts both characters.

`<` and `>` stay bare single-character tokens here; `<=`/`>=` arrive with the operators that use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)