### PR TITLE
Unify the comparison nodes behind a single Comparison base

### DIFF
--- a/src/Comparison.php
+++ b/src/Comparison.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Span;
+use Override;
+
+use function sprintf;
+
+/**
+ * A comparison of two operands by one of the comparison operators. Everything a comparison does—printing, evaluating,
+ * type-checking, comparing itself to another expression—is the same whichever operator it holds, and lives here; the
+ * operator only supplies the symbol and the rule that decides it, both carried by {@see ComparisonOperator}.
+ *
+ * `===` and `>` each keep a final subclass of their own ({@see Eq}, {@see Gt}), only because
+ * {@see Expression::eq()} and {@see Expression::gt()} have declared those return types since before this class
+ * existed—see {@see Eq} for why that pins them. The class isn't abstract, so an operator that needs no such subclass
+ * is a plain instance of it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+class Comparison extends Expression
+{
+    public function __construct(
+        private readonly ComparisonOperator $operator,
+        public readonly Expression $left,
+        public readonly Expression $right,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '%s %s %s',
+            Precedence::parenthesize($this->left, Precedence::Additive),
+            $this->operator->value,
+            Precedence::parenthesize($this->right, Precedence::Additive),
+        );
+    }
+
+    #[Override]
+    public function evaluate(Scope $scope): bool
+    {
+        return $this->operator->compare($this->left->evaluate($scope), $this->right->evaluate($scope));
+    }
+
+    #[Override]
+    public function equals(Expression $other): bool
+    {
+        return $other instanceof self
+            && $this->operator === $other->operator
+            && $this->left->equals($other->left)
+            && $this->right->equals($other->right);
+    }
+
+    #[Override]
+    public function getType(): Type
+    {
+        return Type::bool();
+    }
+
+    #[Override]
+    public function location(): Span
+    {
+        return $this->left->location()->to($this->right->location());
+    }
+}

--- a/src/ComparisonOperator.php
+++ b/src/ComparisonOperator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+/**
+ * The comparison operators, each paired with the rule that decides it: `===` compares any two values of the same type
+ * by deep structural equality ({@see ValueEquality}), `>` compares two numbers. This only says how a pair of operands
+ * that already type-checks is decided; which operands an operator will accept is {@see Expr::checkComparison()}'s
+ * business. Keeping that there rather than here is what holds the dependencies one way: this enum needs to know about
+ * runtime values and nothing else, while deciding what an operator accepts means knowing about {@see Expression},
+ * {@see Type} and the errors raised for a mismatch.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+enum ComparisonOperator: string
+{
+    case Equals = '===';
+    case GreaterThan = '>';
+
+    public function compare(mixed $left, mixed $right): bool
+    {
+        return match ($this) {
+            self::Equals => ValueEquality::equals($left, $right),
+            self::GreaterThan => Operand::number($left) > Operand::number($right),
+        };
+    }
+}

--- a/src/Eq.php
+++ b/src/Eq.php
@@ -4,84 +4,20 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
-use Override;
-
-use function array_key_exists;
-use function count;
-use function get_object_vars;
-use function is_object;
-use function sprintf;
-
 /**
+ * The `===` comparison: a {@see Comparison} holding {@see ComparisonOperator::Equals}, and nothing else. The class
+ * survives because {@see Expression::eq()} has declared it as its return type since before Comparison existed, and
+ * Expression is public API: consumers may type against what eq() returns, so widening the declaration to Comparison
+ * is a breaking change—the backward-compatibility check in CI flags exactly that. Folds into Comparison in the next
+ * breaking release, together with {@see Gt}.
+ *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class Eq extends Expression
+final class Eq extends Comparison
 {
-    public function __construct(public readonly Expression $left, public readonly Expression $right)
+    public function __construct(Expression $left, Expression $right)
     {
-    }
-
-    private static function compareStructs(object $left, object $right): bool
-    {
-        $leftVars = get_object_vars($left);
-        $rightVars = get_object_vars($right);
-        if (count($leftVars) !== count($rightVars)) {
-            return false;
-        }
-        /** @var mixed $value */
-        foreach ($leftVars as $key => $value) {
-            if (!array_key_exists($key, $rightVars)) {
-                return false;
-            }
-            if (!self::compareValues($value, $rightVars[$key])) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static function compareValues(mixed $left, mixed $right): bool
-    {
-        if (is_object($left) && is_object($right)) {
-            return self::compareStructs($left, $right);
-        }
-        return $left === $right;
-    }
-
-    public function __toString(): string
-    {
-        return sprintf(
-            '%s === %s',
-            Precedence::parenthesize($this->left, Precedence::Additive),
-            Precedence::parenthesize($this->right, Precedence::Additive),
-        );
-    }
-
-    #[Override]
-    public function evaluate(Scope $scope): bool
-    {
-        return self::compareValues($this->left->evaluate($scope), $this->right->evaluate($scope));
-    }
-
-    #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->left->equals($other->left)
-            && $this->right->equals($other->right);
-    }
-
-    #[Override]
-    public function getType(): Type
-    {
-        return Type::bool();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->left->location()->to($this->right->location());
+        parent::__construct(ComparisonOperator::Equals, $left, $right);
     }
 }

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -40,16 +40,7 @@ final class Expr
 
     public static function eq(Expression $left, Expression $right): Eq
     {
-        if (!$right->matchesType($left->getType())) {
-            throw TypeError::create(
-                sprintf(
-                    'The expressions of both sides of === must be of the same type. Left: %s, right: %s',
-                    $left->getType(),
-                    $right->getType(),
-                ),
-                $right->location(),
-            );
-        }
+        self::checkComparison(ComparisonOperator::Equals, $left, $right);
         return new Eq($left, $right);
     }
 
@@ -145,11 +136,7 @@ final class Expr
 
     public static function gt(Expression $left, Expression $right): Gt
     {
-        self::assertSameNumberType($left, $right, static fn(Expression $bad, Expression $good): string => sprintf(
-            'Can\'t compare %s to %s',
-            $bad->getType(),
-            $good->getType(),
-        ));
+        self::checkComparison(ComparisonOperator::GreaterThan, $left, $right);
         return new Gt($left, $right);
     }
 
@@ -202,6 +189,20 @@ final class Expr
     }
 
     /**
+     * Which rule an operator's operands have to satisfy, for every operator in one place. The two rules answer
+     * different questions: `===` compares for equality, so its operands only have to be of the same type, while an
+     * ordering operator needs operands that have an order at all. Stating the split once means a further operator has
+     * to be classified rather than copied from whichever neighbor happened to look closest.
+     */
+    private static function checkComparison(ComparisonOperator $operator, Expression $left, Expression $right): void
+    {
+        match ($operator) {
+            ComparisonOperator::Equals => self::assertSameType($left, $right, $operator->value),
+            ComparisonOperator::GreaterThan => self::assertComparable($left, $right),
+        };
+    }
+
+    /**
      * int and float are the only types the arithmetic and ordering operators accept. Note that this has nothing to do
      * with PHP's is_numeric(): a numeric string is a string.
      */
@@ -209,6 +210,39 @@ final class Expr
     {
         $type = $expr->getType();
         return $type->equals(Type::int()) || $type->equals(Type::float());
+    }
+
+    /**
+     * The rule an equality operator follows: the two sides have to be of the same type, whatever that type is. The
+     * error points at the right-hand side, the one measured against the left, and names the operator it was made with.
+     */
+    private static function assertSameType(Expression $left, Expression $right, string $operator): void
+    {
+        if ($right->matchesType($left->getType())) {
+            return;
+        }
+        throw TypeError::create(
+            sprintf(
+                'The expressions of both sides of %s must be of the same type. Left: %s, right: %s',
+                $operator,
+                $left->getType(),
+                $right->getType(),
+            ),
+            $right->location(),
+        );
+    }
+
+    /**
+     * The rule an ordering operator follows. They all compare two numbers the same way, so they share one check and
+     * one wording, and can't drift into blaming different parts of the expression for the same mistake.
+     */
+    private static function assertComparable(Expression $left, Expression $right): void
+    {
+        self::assertSameNumberType($left, $right, static fn(Expression $bad, Expression $good): string => sprintf(
+            'Can\'t compare %s to %s',
+            $bad->getType(),
+            $good->getType(),
+        ));
     }
 
     /**

--- a/src/Gt.php
+++ b/src/Gt.php
@@ -4,53 +4,18 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
-use Override;
-
-use function sprintf;
-
 /**
+ * The `>` comparison: a {@see Comparison} holding {@see ComparisonOperator::GreaterThan}. It survives for the same
+ * reason {@see Eq} does—{@see Expression::gt()} has declared this return type since before Comparison existed—and
+ * folds into Comparison with it in the next breaking release.
+ *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class Gt extends Expression
+final class Gt extends Comparison
 {
-    public function __construct(private readonly Expression $left, private readonly Expression $right)
+    public function __construct(Expression $left, Expression $right)
     {
-    }
-
-    public function __toString(): string
-    {
-        return sprintf(
-            '%s > %s',
-            Precedence::parenthesize($this->left, Precedence::Additive),
-            Precedence::parenthesize($this->right, Precedence::Additive),
-        );
-    }
-
-    #[Override]
-    public function evaluate(Scope $scope): bool
-    {
-        return Operand::number($this->left->evaluate($scope)) > Operand::number($this->right->evaluate($scope));
-    }
-
-    #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->left->equals($other->left)
-            && $this->right->equals($other->right);
-    }
-
-    #[Override]
-    public function getType(): Type
-    {
-        return Type::bool();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->left->location()->to($this->right->location());
+        parent::__construct(ComparisonOperator::GreaterThan, $left, $right);
     }
 }

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -87,7 +87,7 @@ enum Precedence: int
             $expr instanceof Lambda => self::Lambda,
             $expr instanceof Or_ => self::Or,
             $expr instanceof And_ => self::And,
-            $expr instanceof Eq, $expr instanceof Gt => self::Comparison,
+            $expr instanceof Comparison => self::Comparison,
             $expr instanceof Subtract => self::Additive,
             $expr instanceof Negative => self::Unary,
             default => self::Primary,

--- a/src/ValueEquality.php
+++ b/src/ValueEquality.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use function array_key_exists;
+use function count;
+use function get_object_vars;
+use function is_object;
+
+/**
+ * The deep, structural equality that both `===` and `!==` ({@see ComparisonOperator}) are defined in terms of: scalars
+ * compare by identity, structs field by field, recursively. It lives here rather than on the operator so that `!==` can
+ * be exactly the negation of `===` without either one restating the rule.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class ValueEquality
+{
+    /**
+     * @psalm-suppress UnusedConstructor
+     */
+    private function __construct()
+    {
+    }
+
+    public static function equals(mixed $left, mixed $right): bool
+    {
+        if (is_object($left) && is_object($right)) {
+            return self::structsEqual($left, $right);
+        }
+        return $left === $right;
+    }
+
+    private static function structsEqual(object $left, object $right): bool
+    {
+        $leftVars = get_object_vars($left);
+        $rightVars = get_object_vars($right);
+        if (count($leftVars) !== count($rightVars)) {
+            return false;
+        }
+        /** @var mixed $value */
+        foreach ($leftVars as $key => $value) {
+            if (!array_key_exists($key, $rightVars)) {
+                return false;
+            }
+            if (!self::equals($value, $rightVars[$key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -6,12 +6,11 @@ namespace Eventjet\Ausdruck\Test\Unit;
 
 use Eventjet\Ausdruck\And_;
 use Eventjet\Ausdruck\Call;
-use Eventjet\Ausdruck\Eq;
+use Eventjet\Ausdruck\ComparisonOperator;
 use Eventjet\Ausdruck\Expr;
 use Eventjet\Ausdruck\Expression;
 use Eventjet\Ausdruck\FieldAccess;
 use Eventjet\Ausdruck\Get;
-use Eventjet\Ausdruck\Gt;
 use Eventjet\Ausdruck\Lambda;
 use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\Literal;
@@ -91,15 +90,15 @@ final class ExpressionComparisonTest extends TestCase
      */
     public static function notEqualsCases(): iterable
     {
-        yield Eq::class . ': left is different' => [
+        yield ComparisonOperator::Equals->name . ': left is different' => [
             Expr::eq(Expr::literal('a'), Expr::literal('a')),
             Expr::eq(Expr::literal('b'), Expr::literal('a')),
         ];
-        yield Eq::class . ': right is different' => [
+        yield ComparisonOperator::Equals->name . ': right is different' => [
             Expr::eq(Expr::literal('a'), Expr::literal('a')),
             Expr::eq(Expr::literal('a'), Expr::literal('b')),
         ];
-        yield Eq::class . ': different type' => [
+        yield ComparisonOperator::Equals->name . ': different type' => [
             Expr::eq(Expr::literal('a'), Expr::literal('a')),
             Expr::or_(Expr::literal(true), Expr::literal(false)),
         ];
@@ -219,19 +218,19 @@ final class ExpressionComparisonTest extends TestCase
             Expr::literal(1)->call('foo', Type::int(), []),
             Expr::literal(1),
         ];
-        yield Gt::class . ': left is different' => [
+        yield ComparisonOperator::GreaterThan->name . ': left is different' => [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
             Expr::gt(Expr::literal(2), Expr::literal(2)),
         ];
-        yield Gt::class . ': right is different' => [
+        yield ComparisonOperator::GreaterThan->name . ': right is different' => [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
             Expr::gt(Expr::literal(1), Expr::literal(1)),
         ];
-        yield Gt::class . ': both are different' => [
+        yield ComparisonOperator::GreaterThan->name . ': both are different' => [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
             Expr::gt(Expr::literal(2), Expr::literal(1)),
         ];
-        yield Gt::class . ': different type' => [
+        yield ComparisonOperator::GreaterThan->name . ': different type' => [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
             Expr::eq(Expr::literal(1), Expr::literal(2)),
         ];


### PR DESCRIPTION
Split from #62.

`Eq` and `Gt` were separate `Expression` subclasses that differed only in the symbol they printed and the rule that decided them. Everything else — `__toString`'s parenthesization, `getType()` returning bool, `location()` spanning both operands, `equals()` recursing into left and right — was duplicated between them, and each new operator would have duplicated it again.

`Comparison` now holds all of that once and delegates the two things that actually differ to a `ComparisonOperator`: the symbol, and `compare()`, which decides a pair of values that has already type-checked. The equality rule moves to `ValueEquality`, where it is one recursive definition rather than a pair of private helpers on `Eq`.

Which operands an operator *accepts* stays on `Expr` rather than moving to the enum, which keeps the dependencies pointing one way: `ComparisonOperator` needs to know about runtime values and nothing else, while deciding what an operator accepts means knowing about `Expression`, `Type` and the errors raised for a mismatch. `Expr::checkComparison()` states that split in one exhaustive match.

`Eq` and `Gt` survive as final subclasses that only pick their operator. `Expression::eq()` and `gt()` have declared those return types since before `Comparison` existed, and `Expression` is public API, so widening them to `Comparison` is a BC break — `roave-backward-compatibility-check` flags exactly that. They fold into `Comparison` in the next breaking release.

**No behavior change**: the printed forms, the error messages and the precedence are the ones `Eq` and `Gt` already produced. The test count and assertion count are unchanged from `0.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)