### PR TITLE
Let a type parser that reads a type return one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- **Type argument lists now require commas between their elements.** `map<string int>`, `list<int string>` and
+  `fn(int string) -> bool` used to parse as if the comma were there; they are now syntax errors naming the bracket the
+  list is missing (`Expected >, got int`). Every other list in the language already required commas, and the
+  documented spelling has always been `map<K, V>`.
+
+  This affects type strings wherever they are written: inline annotations in expressions passed to
+  `ExpressionParser::parse()`, and whole types passed to `TypeParser::parseString()` and
+  `TypeParser::parseDeclarations()`. Nothing that parsed to one type now parses to a different one — the only change
+  is that comma-less lists are rejected rather than accepted — so a type string that reads correctly today keeps its
+  meaning. Type strings kept outside the codebase, in configuration or a database, are the ones worth checking.
+
+  One caveat on where the error lands. A `<` after a name that is not a built-in generic constructor might be a
+  less-than, so the argument list after it is only *tried*, and any error inside it merely rules that reading out —
+  including an error from a committed constructor nested within. A missing comma nested in such a list is therefore
+  blamed on the outer `<`, which may be far from the mistake: `MyType<map<string int>>` reports `Unexpected <` at
+  column 7, not the missing comma at column 18. The same mistake outside a speculative list reads well
+  (`list<list<int int>>` gives `Expected >, got int` at the `int`). Reporting the nearest mistake instead would mean
+  keeping the furthest failure across every reading tried, which this parser does not yet do.
+
+- Syntax errors say `end of input` where some of them used to say `end of string`, and a type that is required in a
+  named position says so: `Expected return type, got end of input` rather than `Expected type after colon`, and
+  `Expected type for Foo, got ->` for a declaration in `TypeParser::parseDeclarations()`. Error messages are not
+  covered by the backward-compatibility promise, but code matching on them will need updating.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ The following types are supported:
   ExpressionParser::parse('foo:MyType', ['MyType' => Type::alias(Type::listOf(Type::string()))]);
   ```
 
+Type arguments are separated by commas, like every other list in the language: `map<string, int>`, not
+`map<string int>`. A trailing one is allowed — `map<string, int,>` — so a type spread over several lines can end each
+of them the same way.
+
 ### Functions
 
 Syntax: `target.functionName:returnType(arg1, arg2, ...)`

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -13,10 +13,8 @@ use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\StructLiteral;
 use Eventjet\Ausdruck\Type;
 
-use function assert;
 use function is_string;
 use function sprintf;
-use function str_split;
 
 /**
  * Expressions are parsed as a cascade of precedence levels, from loosest to tightest binding:
@@ -35,10 +33,14 @@ use function str_split;
 final class ExpressionParser
 {
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * The reader of the types written inside an expression, over the same stream this one reads: a `:int` is read by
+     * handing the stream over and carrying on where it left off.
      */
-    private function __construct(private Peekable $tokens, private Declarations $declarations)
+    private readonly TypeParser $typeParser;
+
+    private function __construct(private readonly Tokens $tokens, private readonly Declarations $declarations)
     {
+        $this->typeParser = new TypeParser($tokens);
     }
 
     public static function parse(string $expression, Declarations|Types|null $types = null): Expression
@@ -49,14 +51,7 @@ final class ExpressionParser
         if ($types instanceof Types) {
             $types = new Declarations($types);
         }
-        $declarations = $types;
-        $chars = $expression === '' ? [] : str_split($expression);
-        /**
-         * @infection-ignore-all Currently, there's no difference between str_split and its multibyte version. Multibyte
-         *     string literals and identifiers are just put back together. If you encounter a case where it does matter,
-         *     just change it to mb_str_split and add an appropriate test case.
-         */
-        return (new self(new Peekable(Tokenizer::tokenize($chars)), $declarations))->parseComplete();
+        return (new self(Tokens::of($expression), $types))->parseComplete();
     }
 
     public static function parseTyped(string $expression, Type $type, Declarations|Types|null $types = null): Expression
@@ -97,7 +92,7 @@ final class ExpressionParser
     private function parseOr(): Expression
     {
         $left = $this->parseAnd();
-        while ($this->nextToken() === Token::Or) {
+        while ($this->tokens->peekToken() === Token::Or) {
             $this->tokens->next();
             $left = $left->or_($this->parseAnd());
         }
@@ -111,7 +106,7 @@ final class ExpressionParser
     private function parseAnd(): Expression
     {
         $left = $this->parseComparison();
-        while ($this->nextToken() === Token::And) {
+        while ($this->tokens->peekToken() === Token::And) {
             $this->tokens->next();
             $left = $left->and_($this->parseComparison());
         }
@@ -130,7 +125,7 @@ final class ExpressionParser
     private function parseComparison(): Expression
     {
         $left = $this->parseAdditive();
-        $build = match ($this->nextToken()) {
+        $build = match ($this->tokens->peekToken()) {
             Token::TripleEquals => $left->eq(...),
             Token::NotEquals => $left->neq(...),
             Token::CloseAngle => $left->gt(...),
@@ -153,7 +148,7 @@ final class ExpressionParser
     private function parseAdditive(): Expression
     {
         $left = $this->parseUnary();
-        while ($this->nextToken() === Token::Minus) {
+        while ($this->tokens->peekToken() === Token::Minus) {
             $this->tokens->next();
             $left = $left->subtract($this->parseUnary());
         }
@@ -186,7 +181,7 @@ final class ExpressionParser
     private function parsePostfix(): Expression
     {
         $expr = $this->parsePrimary();
-        while ($this->nextToken() === Token::Dot) {
+        while ($this->tokens->peekToken() === Token::Dot) {
             $expr = $this->dot($expr);
         }
         return $expr;
@@ -199,7 +194,7 @@ final class ExpressionParser
     {
         $parsedToken = $this->tokens->peek();
         if ($parsedToken === null) {
-            throw SyntaxError::create('Expected expression, got end of input', $this->nextSpan());
+            throw $this->tokens->expected('expression');
         }
         $token = $parsedToken->token;
         if ($token === 'true') {
@@ -230,10 +225,7 @@ final class ExpressionParser
         if ($token === Token::OpenParen) {
             return $this->group();
         }
-        throw SyntaxError::create(
-            sprintf('Expected expression, got %s', Token::print($token)),
-            $parsedToken->location(),
-        );
+        throw $this->tokens->expected('expression');
     }
 
     /**
@@ -246,9 +238,9 @@ final class ExpressionParser
      */
     private function group(): Expression
     {
-        $this->expect(Token::OpenParen);
+        $this->tokens->expect(Token::OpenParen);
         $inner = $this->parseExpression();
-        $this->expect(Token::CloseParen);
+        $this->tokens->expect(Token::CloseParen);
         return $inner;
     }
 
@@ -261,7 +253,7 @@ final class ExpressionParser
     private function variable(string $name, Span $start): Get
     {
         $declaredType = $this->declarations->variables[$name] ?? null;
-        if ($this->nextToken() !== Token::Colon) {
+        if ($this->tokens->peekToken() !== Token::Colon) {
             if ($declaredType !== null) {
                 return Expr::get($name, new TypeHint($declaredType, false), $start);
             }
@@ -270,17 +262,8 @@ final class ExpressionParser
                 $start,
             );
         }
-        $this->expect(Token::Colon);
-        $typeNode = TypeParser::parse($this->tokens);
-        if ($typeNode === null) {
-            throw SyntaxError::create('Expected type, got end of string', $this->nextSpan());
-        }
-        if ($typeNode instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected type, got %s', Token::print($typeNode->token)),
-                $typeNode->location(),
-            );
-        }
+        $this->tokens->expect(Token::Colon);
+        $typeNode = $this->typeParser->type();
         $type = $this->declarations->types->resolve($typeNode);
         if ($type instanceof TypeError) {
             throw $type;
@@ -299,73 +282,27 @@ final class ExpressionParser
         return Expr::get($name, $type, $start->to($typeNode->location));
     }
 
-    private function expect(Token $expected): ParsedToken
-    {
-        $actual = $this->tokens->peek();
-        if ($actual === null) {
-            $previousToken = $this->tokens->previous();
-            assert($previousToken !== null);
-            $span = Span::char($previousToken->line, $previousToken->column + 1);
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', Token::print($expected)), $span);
-        }
-        if ($actual->token === $expected) {
-            $this->tokens->next();
-            return $actual;
-        }
-        throw SyntaxError::create(
-            sprintf('Expected %s, got %s', Token::print($expected), Token::print($actual->token)),
-            $actual->location(),
-        );
-    }
-
-    /**
-     * The body of every bracketed, comma-separated list in the language: call arguments, list items, struct fields and
-     * lambda parameters.
-     *
-     * A trailing comma is allowed. A missing one simply ends the list, which leaves the caller's expect($close) to
-     * report the token that isn't a comma.
-     *
-     * @template T
-     * @param callable(): T $parseItem
-     * @return list<T>
-     */
-    private function parseCommaSeparated(Token $close, callable $parseItem): array
-    {
-        $items = [];
-        while (true) {
-            $token = $this->nextToken();
-            if ($token === null || $token === $close) {
-                return $items;
-            }
-            $items[] = $parseItem();
-            if ($this->nextToken() !== Token::Comma) {
-                return $items;
-            }
-            $this->tokens->next();
-        }
-    }
-
     /**
      * |one, two, three, | item:string === needle:string
      * =================================================
      */
     private function lambda(): Expression
     {
-        $start = $this->expect(Token::Pipe);
-        $params = $this->parseCommaSeparated(
+        $start = $this->tokens->expect(Token::Pipe);
+        $params = $this->tokens->commaSeparated(
             Token::Pipe,
-            fn(): string => $this->expectIdentifier('parameter name')[0],
+            fn(): string => $this->tokens->expectIdentifier('parameter name')[0],
         );
-        $this->expect(Token::Pipe);
+        $this->tokens->expect(Token::Pipe);
         $body = $this->parseExpression();
         return Expr::lambda($body, $params, $start->location()->to($body->location()));
     }
 
     private function dot(Expression $target): Call|FieldAccess
     {
-        $this->expect(Token::Dot);
-        [$name, $nameLocation] = $this->expectIdentifier('function name');
-        $token = $this->nextToken();
+        $this->tokens->expect(Token::Dot);
+        [$name, $nameLocation] = $this->tokens->expectIdentifier('function name');
+        $token = $this->tokens->peekToken();
         return match ($token) {
             Token::Colon, Token::OpenParen => $this->call($name, $nameLocation, $target),
             default => Expr::fieldAccess($target, $name, $target->location()->to($nameLocation)),
@@ -380,9 +317,9 @@ final class ExpressionParser
     {
         $signature = $this->declarations->functions[$name] ?? null;
         $returnType = $this->returnType();
-        $this->expect(Token::OpenParen);
-        $args = $this->parseCommaSeparated(Token::CloseParen, $this->parseExpression(...));
-        $closeParen = $this->expect(Token::CloseParen);
+        $this->tokens->expect(Token::OpenParen);
+        $args = $this->tokens->commaSeparated(Token::CloseParen, $this->parseExpression(...));
+        $closeParen = $this->tokens->expect(Token::CloseParen);
         return Expr::call(
             $target,
             $name,
@@ -404,20 +341,11 @@ final class ExpressionParser
      */
     private function returnType(): TypeAnnotation|null
     {
-        if ($this->nextToken() !== Token::Colon) {
+        if ($this->tokens->peekToken() !== Token::Colon) {
             return null;
         }
-        $this->expect(Token::Colon);
-        $typeNode = TypeParser::parse($this->tokens);
-        if ($typeNode === null) {
-            throw SyntaxError::create('Expected type after colon', $this->nextSpan());
-        }
-        if ($typeNode instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected type after colon, got %s', Token::print($typeNode->token)),
-                $typeNode->location(),
-            );
-        }
+        $this->tokens->expect(Token::Colon);
+        $typeNode = $this->typeParser->type('return type');
         $returnType = $this->declarations->types->resolve($typeNode);
         if ($returnType instanceof TypeError) {
             throw $returnType;
@@ -426,53 +354,14 @@ final class ExpressionParser
     }
 
     /**
-     * @return array{string, Span}
-     */
-    private function expectIdentifier(string $expected): array
-    {
-        $name = $this->tokens->peek();
-        if ($name === null) {
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', $expected), $this->nextSpan());
-        }
-        if (!is_string($name->token)) {
-            throw SyntaxError::create(
-                sprintf('Expected %s, got %s', $expected, Token::print($name->token)),
-                $name->location(),
-            );
-        }
-        $this->tokens->next();
-        return [$name->token, $name->location()];
-    }
-
-    /**
-     * The token the parser is looking at, or null at the end of the input.
-     *
-     * @return Token | string | Literal<string | int | float | bool> | null
-     */
-    private function nextToken(): Token|string|Literal|null
-    {
-        return $this->tokens->peek()?->token;
-    }
-
-    private function nextSpan(): Span
-    {
-        $token = $this->tokens->peek();
-        if ($token !== null) {
-            return Span::char($token->line, $token->column);
-        }
-        $previous = $this->tokens->previous();
-        return $previous === null ? Span::char(1, 1) : Span::char($previous->line, $previous->column + 1);
-    }
-
-    /**
      * [1 - 2, foo:int]
      * ================
      */
     private function parseListLiteral(): ListLiteral
     {
-        $start = $this->expect(Token::OpenBracket);
-        $items = $this->parseCommaSeparated(Token::CloseBracket, $this->parseExpression(...));
-        $close = $this->expect(Token::CloseBracket);
+        $start = $this->tokens->expect(Token::OpenBracket);
+        $items = $this->tokens->commaSeparated(Token::CloseBracket, $this->parseExpression(...));
+        $close = $this->tokens->expect(Token::CloseBracket);
         return Expr::listLiteral($items, $start->location()->to($close->location()));
     }
 
@@ -482,12 +371,13 @@ final class ExpressionParser
      */
     private function parseStructLiteral(): StructLiteral
     {
-        $start = $this->expect(Token::OpenBrace);
+        $start = $this->tokens->expect(Token::OpenBrace);
         $fields = [];
-        foreach ($this->parseCommaSeparated(Token::CloseBrace, $this->parseStructField(...)) as [$name, $value]) {
+        $parsed = $this->tokens->commaSeparated(Token::CloseBrace, $this->parseStructField(...));
+        foreach ($parsed as [$name, $value]) {
             $fields[$name] = $value;
         }
-        $close = $this->expect(Token::CloseBrace);
+        $close = $this->tokens->expect(Token::CloseBrace);
         return Expr::structLiteral($fields, $start->location()->to($close->location()));
     }
 
@@ -499,8 +389,8 @@ final class ExpressionParser
      */
     private function parseStructField(): array
     {
-        [$name] = $this->expectIdentifier('field name');
-        $this->expect(Token::Colon);
+        [$name] = $this->tokens->expectIdentifier('field name');
+        $this->tokens->expect(Token::Colon);
         return [$name, $this->parseExpression()];
     }
 }

--- a/src/Parser/Peekable.php
+++ b/src/Parser/Peekable.php
@@ -20,7 +20,7 @@ use function count;
  * never arrived, so the stream is short one item rather than at its end, and it says so however often it is asked.
  *
  * The cursor only moves where it's told; deciding when a reading has failed, and rewinding if it has, is the caller's
- * business. See {@see TypeParser::tryTypeArguments()} for the one place that does.
+ * business.
  *
  * @template T
  * @internal
@@ -62,9 +62,14 @@ final class Peekable
     }
 
     /**
+     * Impure, though it looks like a plain read: it is what pulls from the generator, so a call whose result is
+     * thrown away still buffers an item, still runs whatever the generator does to produce it, and still throws if
+     * that fails. Two calls agree only while the cursor stays put.
+     *
      * @param non-negative-int $ahead How far past the next item to look: peek() shows the next item, peek(1) the one
      *     after it.
      * @return T | null
+     * @phpstan-impure
      */
     public function peek(int $ahead = 0): mixed
     {

--- a/src/Parser/Tokens.php
+++ b/src/Parser/Tokens.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Parser;
+
+use function is_string;
+use function sprintf;
+use function str_split;
+
+/**
+ * The stream of tokens a parser reads, and the reading conventions {@see ExpressionParser} and {@see TypeParser} share:
+ * what it means to require something, where the input ran out, and the shape of every list in the language. Both walk
+ * the same stream, so both had private copies of these; one copy is what keeps the two from drifting apart as either is
+ * edited.
+ *
+ * Requiring something is stated once by {@see self::expected()} and not just for tokens: a type and an expression are
+ * required in the same words and blamed on the same span as a closing bracket, so the two parsers cannot word or locate
+ * the same complaint differently.
+ *
+ * The cursor underneath is a {@see Peekable}, which buffers whatever it is given and knows nothing about tokens—the
+ * tokenizer reads characters through one of its own. Everything token-shaped lives here instead, so a parser holds a
+ * stream that is already of tokens rather than one it has to keep saying is. It also only holds the part of the cursor
+ * a parser has any business with: looking behind is needed to say where the input ran out and nowhere else, so
+ * {@see Peekable::previous()} is not forwarded and {@see self::endOfInput()} is the one place that calls it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck\Parser
+ */
+final class Tokens
+{
+    /**
+     * @param Peekable<ParsedToken> $tokens
+     */
+    private function __construct(private readonly Peekable $tokens)
+    {
+    }
+
+    public static function of(string $source): self
+    {
+        /**
+         * @infection-ignore-all Currently, there's no difference between str_split and its multibyte version. Multibyte
+         *     string literals and identifiers are just put back together. If you encounter a case where it does matter,
+         *     just change it to mb_str_split and add an appropriate test case.
+         */
+        $chars = $source === '' ? [] : str_split($source);
+        return new self(new Peekable(Tokenizer::tokenize($chars)));
+    }
+
+    /**
+     * The token the parser is looking at, or null at the end of the input. Impure for the reason
+     * {@see Peekable::peek()} is: it is the read that scans the token.
+     *
+     * @phpstan-impure
+     */
+    public function peek(): ParsedToken|null
+    {
+        return $this->tokens->peek();
+    }
+
+    /**
+     * Just which token it is, for deciding what to parse next: that decision never depends on where the token is, and
+     * asking for only what it turns on keeps the location out of the conditions.
+     *
+     * @return Token | string | Literal<string | int | float | bool> | null
+     * @phpstan-impure
+     */
+    public function peekToken(): Token|string|Literal|null
+    {
+        return $this->tokens->peek()?->token;
+    }
+
+    /**
+     * Advances past the token the parser is looking at. Nothing is returned: every caller has already peeked the token
+     * it is stepping over, so handing it back again would only be a second way to say what it is.
+     */
+    public function next(): void
+    {
+        $this->tokens->next();
+    }
+
+    /**
+     * The current position, to be handed back to {@see self::restore()}.
+     *
+     * @return non-negative-int
+     */
+    public function snapshot(): int
+    {
+        return $this->tokens->snapshot();
+    }
+
+    /**
+     * @param non-negative-int $snapshot
+     */
+    public function restore(int $snapshot): void
+    {
+        $this->tokens->restore($snapshot);
+    }
+
+    /**
+     * Something was required here and isn't there. One rule with one span policy—blame the token that turned up, or
+     * where the input ran out if none did—so every reading that requires something says so through this rather than
+     * wording and locating its own complaint. What is required needn't be a single token: `type` and `expression` are
+     * asked for the same way `)` is, and are named the same way in the error.
+     *
+     * @param string $what What was required, as the error should name it: a printed token, or a phrase like
+     *     "field name" or "return type".
+     */
+    public function expected(string $what): SyntaxError
+    {
+        $actual = $this->tokens->peek();
+        return SyntaxError::create(
+            $actual === null
+                ? sprintf('Expected %s, got end of input', $what)
+                : sprintf('Expected %s, got %s', $what, Token::print($actual->token)),
+            $actual?->location() ?? $this->endOfInput(),
+        );
+    }
+
+    public function expect(Token $expected): ParsedToken
+    {
+        $actual = $this->tokens->peek();
+        if ($actual === null || $actual->token !== $expected) {
+            throw $this->expected(Token::print($expected));
+        }
+        $this->tokens->next();
+        return $actual;
+    }
+
+    /**
+     * @param string $expected What to call the identifier in the error, e.g. "field name".
+     * @return array{string, Span}
+     */
+    public function expectIdentifier(string $expected): array
+    {
+        $name = $this->tokens->peek();
+        if ($name === null || !is_string($name->token)) {
+            throw $this->expected($expected);
+        }
+        $this->tokens->next();
+        return [$name->token, $name->location()];
+    }
+
+    /**
+     * The body of every bracketed, comma-separated list in the language: type arguments, function parameter types,
+     * struct fields—both the type and the literal—call arguments, list items and lambda parameters.
+     *
+     * A trailing comma is allowed. A missing one simply ends the list, which leaves the caller's expect($close) to
+     * report the token that isn't a comma. Ending on the missing comma rather than on something that can't start
+     * another element is what lets an unclosed list be blamed on the bracket it needs instead of on whatever follows:
+     * `fn(int -> string` asks for the `)`, because the list stopped at a token that wasn't a comma without ever having
+     * to decide whether `->` could begin a parameter. Nothing here knows what an element looks like, so no element can
+     * be added that this has to be taught about.
+     *
+     * That holds from the second element on. The first has no comma before it to be missing, so a list that is neither
+     * empty nor already closed has no choice but to try to read one, and whatever $parseItem makes of the tokens there
+     * is what gets reported: `list<:` is blamed on the `:` that can't start a type, not on the `>` it is also missing.
+     *
+     * The loop ends because $parseItem either consumes a token or throws: a reading that could return having consumed
+     * nothing would leave the stream where it was, and the same token would be read as an element forever.
+     *
+     * @template T
+     * @param Token $close The bracket that ends the list, which the caller takes.
+     * @param callable(): T $parseItem
+     * @return list<T>
+     */
+    public function commaSeparated(Token $close, callable $parseItem): array
+    {
+        $items = [];
+        while (true) {
+            $token = $this->peekToken();
+            if ($token === null || $token === $close) {
+                return $items;
+            }
+            $items[] = $parseItem();
+            if ($this->peekToken() !== Token::Comma) {
+                return $items;
+            }
+            $this->tokens->next();
+        }
+    }
+
+    /**
+     * Where the input ran out: just after the last token read, or the very start of it if there never was one. Just
+     * after the token, that is, not just after the column it starts in—an input ending in `->` ran out two columns on,
+     * not one—which is the extent {@see ParsedToken::location()} carries. Carries rather than computes: the width of
+     * a token cannot be recovered from the token, only from the source, so an input ending in `1.50` ran out four
+     * columns on even though the literal prints back three wide.
+     */
+    public function endOfInput(): Span
+    {
+        $previous = $this->tokens->previous();
+        if ($previous === null) {
+            return Span::char(1, 1);
+        }
+        $end = $previous->location();
+        return Span::char($end->endLine, $end->endColumn + 1);
+    }
+}

--- a/src/Parser/TypeConstructor.php
+++ b/src/Parser/TypeConstructor.php
@@ -58,7 +58,7 @@ enum TypeConstructor: string
     /**
      * Whether a `<` directly after this name opens a type argument list. It does for the constructors that take at
      * least one, and for nothing else, which is what lets `a:int < b:int` read as a comparison: see
-     * {@see TypeParser::parse()}, which has to decide what the `<` is before there is a resolved type to ask.
+     * {@see TypeParser::type()}, which has to decide what the `<` is before there is a resolved type to ask.
      */
     public function takesTypeArguments(): bool
     {

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -5,36 +5,37 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck\Parser;
 
 use function array_merge;
-use function assert;
 use function is_string;
 use function sprintf;
-use function str_split;
 
 /**
- * @phpstan-type AnyToken Token | string | Literal<string | int | float>
+ * Reads types off a stream of tokens. Like {@see ExpressionParser}, it is an object over that stream rather than a set
+ * of statics passing it along: the stream never varies within a parse, so it is state, not an argument, and the
+ * recursive readings can hand each other a closure without one having to capture it.
+ *
+ * The expression parser holds one of these over the same stream, which is what lets a type appear inside an expression:
+ * both are readers of one stream that take turns.
+ *
  * @psalm-internal Eventjet\Ausdruck\Parser
  */
 final class TypeParser
 {
+    public function __construct(private readonly Tokens $tokens)
+    {
+    }
+
     /**
-     * A whole string is a whole type: unlike {@see self::parse()}, which reads one type off a stream the expression
+     * A whole string is a whole type: unlike {@see self::type()}, which reads one type off a stream the expression
      * parser keeps using afterwards, nothing here comes after the type, so a leftover token is an error rather than the
      * caller's business.
      */
     public static function parseString(string $str): TypeNode|SyntaxError
     {
-        $chars = $str === '' ? [] : str_split($str);
-        $tokens = new Peekable(Tokenizer::tokenize($chars));
+        $tokens = Tokens::of($str);
         try {
-            $node = self::parse($tokens);
+            $node = (new self($tokens))->type();
         } catch (SyntaxError $e) {
             return $e;
-        }
-        if ($node instanceof ParsedToken) {
-            return SyntaxError::create(sprintf('Expected type, got %s', Token::print($node->token)), $node->location());
-        }
-        if ($node === null) {
-            return SyntaxError::create('Invalid type ""', Span::char(1, 1));
         }
         $trailing = $tokens->peek();
         if ($trailing !== null) {
@@ -51,216 +52,143 @@ final class TypeParser
      */
     public static function parseDeclarations(string $src): array
     {
-        $tokens = new Peekable(Tokenizer::tokenize($src === '' ? [] : str_split($src)));
+        $tokens = Tokens::of($src);
+        $types = new self($tokens);
         $declarations = [];
-        while (($nameToken = $tokens->peek()) !== null) {
-            $name = $nameToken->token;
-            if (!is_string($name)) {
-                throw SyntaxError::create(
-                    sprintf('Expected type name, got %s', Token::print($name)),
-                    $nameToken->location(),
-                );
-            }
-            $tokens->next();
-            self::expect($tokens, Token::Colon);
-            $node = self::parse($tokens);
-            if ($node === null) {
-                throw SyntaxError::create(
-                    sprintf('Expected a type for %s, got end of input', $name),
-                    $nameToken->location(),
-                );
-            }
-            if (!$node instanceof TypeNode) {
-                throw SyntaxError::create(
-                    sprintf('Expected a type for %s, got %s', $name, Token::print($node->token)),
-                    $node->location(),
-                );
-            }
-            $declarations[$name] = $node;
+        while ($tokens->peek() !== null) {
+            [$name] = $tokens->expectIdentifier('type name');
+            $tokens->expect(Token::Colon);
+            // Named, because a declaration string holds several and the span alone leaves the reader counting them.
+            $declarations[$name] = $types->type(sprintf('type for %s', $name));
         }
         return $declarations;
     }
 
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * Reads one type off the stream. Everywhere a type may appear, one is required, so whether the tokens ahead are a
+     * type at all is settled here rather than handed back for each call site to decode and word its own complaint
+     * about. Lists of types don't have to ask either: {@see Tokens::commaSeparated()} ends on a missing comma, not on
+     * a token that can't start an element, so a type form added here needs no telling anywhere else.
+     *
+     * @param string $expected What to call the type in the error, e.g. "return type"—the same courtesy
+     *     {@see Tokens::expectIdentifier()} extends to names. A call site with nothing more specific to say than
+     *     "type" says nothing.
      */
-    public static function parse(Peekable $tokens): TypeNode|ParsedToken|null
+    public function type(string $expected = 'type'): TypeNode
     {
-        $parsedToken = $tokens->peek();
+        $parsedToken = $this->tokens->peek();
         if ($parsedToken === null) {
-            return null;
+            throw $this->tokens->expected($expected);
         }
         if ($parsedToken->token === Token::OpenBrace) {
-            return self::parseStruct($tokens);
+            return $this->parseStruct($parsedToken->location());
         }
         $name = $parsedToken->token;
         if (!is_string($name)) {
-            return $parsedToken;
+            throw $this->tokens->expected($expected);
         }
-        $tokens->next();
+        $location = $parsedToken->location();
+        $this->tokens->next();
         if ($name === 'fn') {
-            return self::parseFunction($tokens, $parsedToken->location());
+            return $this->parseFunction($location);
         }
-        if ($tokens->peek()?->token !== Token::OpenAngle) {
-            return new TypeNode($name, [], $parsedToken->location());
+        if ($this->tokens->peekToken() !== Token::OpenAngle) {
+            return new TypeNode($name, [], $location);
         }
         if (TypeConstructor::tryFrom($name)?->takesTypeArguments() ?? false) {
             // A generic constructor is committed: the `<` can only be its argument list, so whatever goes wrong in
-            // there is a genuine error, reported where it happens rather than rewound.
-            $tokens->next();
-            $args = self::parseTypeList($tokens);
+            // there is a genuine error, reported where it happens rather than rewound—unless a speculative list
+            // further out is still deciding and swallows it. See self::tryTypeArguments().
+            $this->tokens->next();
+            $args = $this->parseTypeList(Token::CloseAngle);
         } else {
             // Any other name might be an operand rather than a type constructor, and the `<` a less-than: `a:int <
             // b:int` is a comparison. Only a list that parses and closes is a type argument list, so try to read one
             // and hand the `<` back if that isn't what's there. A closed list after a name that takes none
             // (`int<string>`) is read as a type on purpose, so the resolver can reject it by name.
-            $args = self::tryTypeArguments($tokens);
+            $args = $this->tryTypeArguments();
             if ($args === null) {
-                return new TypeNode($name, [], $parsedToken->location());
+                return new TypeNode($name, [], $location);
             }
         }
-        $closeAngle = self::expect($tokens, Token::CloseAngle);
-        return new TypeNode($name, $args, $parsedToken->location()->to($closeAngle->location()));
+        $closeAngle = $this->tokens->expect(Token::CloseAngle);
+        return new TypeNode($name, $args, $location->to($closeAngle->location()));
     }
 
     /**
      * Reads a `<...>` type argument list, stopping on its `>` so the caller can take it. Returns null—leaving the
      * stream exactly where it was—if what follows isn't one after all. A {@see SyntaxError} raised along the way is
      * not an error to report: it only means these tokens aren't a type argument list either, and the caller is one
-     * that has some other reading of the `<` to fall back on. Anything already committed to a type argument list goes
-     * the direct route and lets its errors out.
+     * that has some other reading of the `<` to fall back on.
      *
-     * @param Peekable<ParsedToken> $tokens
+     * That goes for an error from a committed constructor nested inside, too. `MyType<list<int int>>` is blamed on its
+     * outer `<`, not on the comma missing from the inner list, because the reading fallen back to is a less-than, and
+     * it is `MyType < list<int int>>` that then has to make something of the tokens after it. Letting the innermost
+     * error out instead would be wrong wherever the fallback is what the writer meant: `a:MyType < list<int>` is a
+     * comparison, and the list in it closes only because the reading that rewound stopped looking. Telling those two
+     * apart means keeping the furthest failure across every reading tried and reporting that one once they have all
+     * failed—a way of choosing between errors this parser doesn't have.
+     *
      * @return list<TypeNode> | null
      */
-    private static function tryTypeArguments(Peekable $tokens): array|null
+    private function tryTypeArguments(): array|null
     {
-        $snapshot = $tokens->snapshot();
+        $snapshot = $this->tokens->snapshot();
         try {
-            $tokens->next();
-            $args = self::parseTypeList($tokens);
-            if ($tokens->peek()?->token === Token::CloseAngle) {
+            $this->tokens->next();
+            $args = $this->parseTypeList(Token::CloseAngle);
+            if ($this->tokens->peekToken() === Token::CloseAngle) {
                 return $args;
             }
         } catch (SyntaxError) {
         }
-        $tokens->restore($snapshot);
+        $this->tokens->restore($snapshot);
         return null;
     }
 
     /**
-     * map<int, string>
-     *     ===========
+     * The types inside a pair of brackets, wherever a type is written with several:
      *
-     * @param Peekable<ParsedToken> $tokens
+     *     map<int, string>        fn(int, string) -> bool
+     *         ===========            ===========
+     *
+     * @param Token $close The bracket that ends the list, which the caller takes.
      * @return list<TypeNode>
      */
-    private static function parseTypeList(Peekable $tokens): array
+    private function parseTypeList(Token $close): array
     {
-        $args = [];
-        while (true) {
-            $arg = self::parse($tokens);
-            if (!$arg instanceof TypeNode) {
-                break;
-            }
-            $args[] = $arg;
-            if ($tokens->peek()?->token === Token::Comma) {
-                $tokens->next();
-            }
-        }
-        return $args;
+        return $this->tokens->commaSeparated($close, fn(): TypeNode => $this->type());
     }
 
-    /**
-     * @param Peekable<ParsedToken> $tokens
-     * @param AnyToken $expected
-     */
-    private static function expect(Peekable $tokens, Token|string|Literal $expected): ParsedToken
+    private function parseFunction(Span $fnLocation): TypeNode
     {
-        $actual = $tokens->peek();
-        if ($actual === null) {
-            $previousToken = $tokens->previous();
-            assert($previousToken !== null);
-            $span = Span::char($previousToken->line, $previousToken->column + 1);
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', Token::print($expected)), $span);
-        }
-        if ($actual->token === $expected) {
-            $tokens->next();
-            return $actual;
-        }
-        throw SyntaxError::create(
-            sprintf('Expected %s, got %s', Token::print($expected), Token::print($actual->token)),
-            $actual->location(),
-        );
-    }
-
-    /**
-     * @param Peekable<ParsedToken> $tokens
-     */
-    private static function parseFunction(Peekable $tokens, Span $fnLocation): TypeNode
-    {
-        self::expect($tokens, Token::OpenParen);
-        $params = self::parseTypeList($tokens);
-        self::expect($tokens, Token::CloseParen);
-        $arrow = self::expect($tokens, Token::Arrow);
-        $returnType = self::parse($tokens);
-        if ($returnType === null) {
-            throw SyntaxError::create('Expected return type, got end of input', $arrow->location());
-        }
-        if ($returnType instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected return type, got %s', Token::print($returnType->token)),
-                $returnType->location(),
-            );
-        }
+        $this->tokens->expect(Token::OpenParen);
+        $params = $this->parseTypeList(Token::CloseParen);
+        $this->tokens->expect(Token::CloseParen);
+        $this->tokens->expect(Token::Arrow);
+        $returnType = $this->type('return type');
         return new TypeNode('fn', array_merge($params, [$returnType]), $fnLocation->to($returnType->location));
     }
 
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * @param Span $start The location of the `{`, which {@see self::type()} has already peeked.
      */
-    private static function parseStruct(Peekable $tokens): TypeNode
+    private function parseStruct(Span $start): TypeNode
     {
-        $openBraceToken = $tokens->peek();
-        assert($openBraceToken !== null);
-        $start = $openBraceToken->location();
-        $tokens->next();
-        $fields = [];
-        while (true) {
-            $nameToken = $tokens->peek();
-            if ($nameToken === null) {
-                break;
-            }
-            if ($nameToken->token === Token::CloseBrace) {
-                break;
-            }
-            $name = $nameToken->token;
-            if (!is_string($name)) {
-                throw SyntaxError::create(
-                    sprintf('Expected field name, got %s', Token::print($name)),
-                    $nameToken->location(),
-                );
-            }
-            $tokens->next();
-            self::expect($tokens, Token::Colon);
-            $type = self::parse($tokens);
-            if ($type === null) {
-                throw SyntaxError::create('Expected type, got end of input', $nameToken->location());
-            }
-            if (!$type instanceof TypeNode) {
-                throw SyntaxError::create(
-                    sprintf('Expected type, got %s', Token::print($type->token)),
-                    $type->location(),
-                );
-            }
-            $fields[] = TypeNode::keyValue(new TypeNode($name, [], $nameToken->location()), $type);
-            $token = $tokens->peek();
-            if ($token?->token !== Token::Comma) {
-                break;
-            }
-            $tokens->next();
-        }
-        $end = self::expect($tokens, Token::CloseBrace)->location();
+        $this->tokens->next();
+        $fields = $this->tokens->commaSeparated(Token::CloseBrace, fn(): TypeNode => $this->parseField());
+        $end = $this->tokens->expect(Token::CloseBrace)->location();
         return TypeNode::struct($fields, $start->to($end));
+    }
+
+    /**
+     * {name: string, age: int}
+     *  ============
+     */
+    private function parseField(): TypeNode
+    {
+        [$name, $nameLocation] = $this->tokens->expectIdentifier('field name');
+        $this->tokens->expect(Token::Colon);
+        return TypeNode::keyValue(new TypeNode($name, [], $nameLocation), $this->type());
     }
 }

--- a/src/Parser/Types.php
+++ b/src/Parser/Types.php
@@ -146,7 +146,7 @@ final class Types
 
     /**
      * An alias is a name for one complete type, so like the argument-less built-ins, it rejects type arguments instead
-     * of silently dropping them—`Foo<int>` is as invalid as `int<string>`. {@see TypeParser::parse()} counts on that:
+     * of silently dropping them—`Foo<int>` is as invalid as `int<string>`. {@see TypeParser::type()} counts on that:
      * it reads a closed argument list after any name and leaves rejecting it to this resolver.
      */
     private function resolveAlias(TypeNode $node): Type|TypeError|null

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -415,8 +415,15 @@ final class ExpressionParserTest extends TestCase
         // Two `=` after a `>` keep the angle bare, whatever comes next (see the `foo:list<int>===bar` parse case), so
         // the `==` here is blamed as its own broken `===` rather than a `>=` eating its first `=`.
         yield 'greater-equals with an extra equals' => ['a:int >== 1', 'Expected ===, got =='];
-        yield 'end of string variable and colon' => ['foo:'];
-        yield 'end of string after function call and colon' => ['foo:string.substr:'];
+        // A colon promises a type, so running out after one asks for the type, not for whatever the colon was part of.
+        // The return type of a call is named as such; a variable's type has no name of its own to be called by.
+        yield 'end of string variable and colon' => ['foo:', 'Expected type, got end of input'];
+        yield 'non-type token after a variable colon' => ['foo:->', 'Expected type, got ->'];
+        yield 'non-type token after a call colon' => ['a:int.foo:->', 'Expected return type, got ->'];
+        yield 'end of string after function call and colon' => [
+            'foo:string.substr:',
+            'Expected return type, got end of input',
+        ];
         yield 'end of string after function dot' => ['foo:string.'];
         yield 'missing function name' => ['foo:string.:string()'];
         yield 'list literal: missing closing bracket' => ['[1, 2'];

--- a/tests/unit/Parser/TypeParserTest.php
+++ b/tests/unit/Parser/TypeParserTest.php
@@ -30,8 +30,16 @@ final class TypeParserTest extends TestCase
             'fn(int',
             'Expected ), got end of input',
         ];
+        // A type is required everywhere one may appear, so one message serves them all; where a position has a name of
+        // its own, it says that instead of just "type".
+        //
+        // The input ran out one column past the whole `->`, not one past the column it starts in: a token is as wide
+        // as it is written.
         yield 'End of string after function arrow' => [
-            'fn(int) ->',
+            <<<'AUSDRUCK'
+                fn(int) ->
+                          =
+                AUSDRUCK,
             'Expected return type, got end of input',
         ];
         yield 'Dot after function arrow' => [
@@ -40,14 +48,14 @@ final class TypeParserTest extends TestCase
         ];
         yield 'Empty string' => [
             <<<'AUSDRUCK'
-                
+
                 =
                 AUSDRUCK,
-            'Invalid type ""',
+            'Expected type, got end of input',
         ];
         yield 'Whitespace-only string' => [
             '  ',
-            'Invalid type ""',
+            'Expected type, got end of input',
         ];
         yield 'Arrow' => [
             <<<'AUSDRUCK'
@@ -65,7 +73,10 @@ final class TypeParserTest extends TestCase
             'Expected field name, got {',
         ];
         yield 'Struct: end of input after field name' => [
-            '{name',
+            <<<'AUSDRUCK'
+                {name
+                     =
+                AUSDRUCK,
             'Expected :, got end of input',
         ];
         yield 'Struct: missing colon between field name and type' => [
@@ -91,6 +102,46 @@ final class TypeParserTest extends TestCase
         yield 'Struct: no comma between fields' => [
             '{name: string age: int}',
             'Expected }, got age',
+        ];
+        // An argument list ends at the first missing comma, so whatever follows gets blamed as the closing bracket it
+        // isn't. Forgetting the bracket is the likelier mistake, and this names it. What the token is doesn't matter:
+        // a type, a literal or an operator all end the list the same way, so a type argument list separates its
+        // elements with commas exactly like every other list in the language.
+        yield 'Type instead of a second type argument' => [
+            'list<int string>',
+            'Expected >, got string',
+        ];
+        yield 'Literal instead of a second type argument' => [
+            'list<int 42>',
+            'Expected >, got 42',
+        ];
+        yield 'Type instead of a second function parameter' => [
+            'fn(int string) -> bool',
+            'Expected ), got string',
+        ];
+        yield 'Literal instead of a second function parameter' => [
+            'fn(int 42) -> string',
+            'Expected ), got 42',
+        ];
+        yield 'Unclosed function parameter list' => [
+            'fn(int -> string',
+            'Expected ), got ->',
+        ];
+        yield 'Unclosed type argument list' => [
+            'list<int .',
+            'Expected >, got .',
+        ];
+        // A `<` after a name that isn't a generic constructor might be a less-than, so the argument list after it is
+        // only tried, and any error inside it merely rules that reading out. A broken list nested in one is nested in
+        // the trying too, which is why the outer `<` is blamed rather than the comma the inner list is missing—the
+        // reading fallen back to is a less-than, and it is that one the tokens after it then have to fit.
+        yield 'Committed type argument list broken inside a speculative one' => [
+            'MyType<list<int int>>',
+            'Unexpected <',
+        ];
+        yield 'Committed type argument list broken on its own' => [
+            'list<list<int int>>',
+            'Expected >, got int',
         ];
         // A type string is a whole type, so anything after the first complete one is an error rather than ignored.
         yield 'Trailing identifier' => [
@@ -212,8 +263,13 @@ final class TypeParserTest extends TestCase
     {
         yield 'Name is not an identifier' => ['42: int', 'Expected type name, got 42'];
         yield 'Missing colon after name' => ['Foo int', 'Expected :, got int'];
-        yield 'End of input after colon' => ['Foo:', 'Expected a type for Foo, got end of input'];
-        yield 'Non-type token after colon' => ['Foo: ->', 'Expected a type for Foo, got ->'];
+        // A declaration string holds several declarations, so the one that is broken says which it is.
+        yield 'End of input after colon' => ['Foo:', 'Expected type for Foo, got end of input'];
+        yield 'Non-type token after colon' => ['Foo: ->', 'Expected type for Foo, got ->'];
+        yield 'Second declaration is the broken one' => [
+            'Foo: int Bar: ->',
+            'Expected type for Bar, got ->',
+        ];
     }
 
     #[DataProvider('syntaxErrorCases')]


### PR DESCRIPTION
`TypeParser::parse` handed back a tri-state `TypeNode|ParsedToken|null` that every caller re-decoded into its own worded, located complaint. This makes the parser an object over a shared `Tokens` stream whose `type()` reads one type and, since a type is required everywhere it may appear, throws the one complaint here instead of returning the ambiguity outward.

`Tokens` owns the reading conventions both parsers kept private copies of: what it means to require something, where the input ran out, and the shape of every bracketed, comma-separated list.

### Behavior changes
- **Type argument lists now require commas** between their elements (routing them through the shared list body). `map<string int>` and friends are now syntax errors naming the bracket the list is missing.
- **Error messages** are unified/renamed (`end of input` rather than `end of string`; a required type in a named position says so).

Split from #70. This is the first of two slices and is independently mergeable.