### PR TITLE
Let a token remember how wide it is written, not how wide it prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- **Type argument lists now require commas between their elements.** `map<string int>`, `list<int string>` and
+  `fn(int string) -> bool` used to parse as if the comma were there; they are now syntax errors naming the bracket the
+  list is missing (`Expected >, got int`). Every other list in the language already required commas, and the
+  documented spelling has always been `map<K, V>`.
+
+  This affects type strings wherever they are written: inline annotations in expressions passed to
+  `ExpressionParser::parse()`, and whole types passed to `TypeParser::parseString()` and
+  `TypeParser::parseDeclarations()`. Nothing that parsed to one type now parses to a different one — the only change
+  is that comma-less lists are rejected rather than accepted — so a type string that reads correctly today keeps its
+  meaning. Type strings kept outside the codebase, in configuration or a database, are the ones worth checking.
+
+  One caveat on where the error lands. A `<` after a name that is not a built-in generic constructor might be a
+  less-than, so the argument list after it is only *tried*, and any error inside it merely rules that reading out —
+  including an error from a committed constructor nested within. A missing comma nested in such a list is therefore
+  blamed on the outer `<`, which may be far from the mistake: `MyType<map<string int>>` reports `Unexpected <` at
+  column 7, not the missing comma at column 18. The same mistake outside a speculative list reads well
+  (`list<list<int int>>` gives `Expected >, got int` at the `int`). Reporting the nearest mistake instead would mean
+  keeping the furthest failure across every reading tried, which this parser does not yet do.
+
+- Syntax errors say `end of input` where some of them used to say `end of string`, and a type that is required in a
+  named position says so: `Expected return type, got end of input` rather than `Expected type after colon`, and
+  `Expected type for Foo, got ->` for a declaration in `TypeParser::parseDeclarations()`. Error messages are not
+  covered by the backward-compatibility promise, but code matching on them will need updating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,14 @@
   named position says so: `Expected return type, got end of input` rather than `Expected type after colon`, and
   `Expected type for Foo, got ->` for a declaration in `TypeParser::parseDeclarations()`. Error messages are not
   covered by the backward-compatibility promise, but code matching on them will need updating.
+
+### Fixed
+
+- Tokens are now located as wide as they are written rather than as wide as they print back, so an error at the end of
+  the input points just past the whole last token instead of somewhere inside it. `{name` is reported at column 6
+  instead of column 3. This was most visible after a number literal that does not round-trip: `[007` reported column 3
+  — a column the input has not even reached — and now reports 5, and `[1, 2.50` reported 8 and now reports 9. The same
+  correction applies to the span of the token itself, so `list<1.50>` underlines all four columns of the literal.
+
+- A string literal written across two lines no longer throws off the line number of every token after it. In
+  `["a`, newline, `b", &]` the `&` is now reported on line 2, where it is written, rather than line 1.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ The following types are supported:
   ExpressionParser::parse('foo:MyType', ['MyType' => Type::alias(Type::listOf(Type::string()))]);
   ```
 
+Type arguments are separated by commas, like every other list in the language: `map<string, int>`, not
+`map<string int>`. A trailing one is allowed — `map<string, int,>` — so a type spread over several lines can end each
+of them the same way.
+
 ### Functions
 
 Syntax: `target.functionName:returnType(arg1, arg2, ...)`

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -13,10 +13,8 @@ use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\StructLiteral;
 use Eventjet\Ausdruck\Type;
 
-use function assert;
 use function is_string;
 use function sprintf;
-use function str_split;
 
 /**
  * Expressions are parsed as a cascade of precedence levels, from loosest to tightest binding:
@@ -35,10 +33,14 @@ use function str_split;
 final class ExpressionParser
 {
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * The reader of the types written inside an expression, over the same stream this one reads: a `:int` is read by
+     * handing the stream over and carrying on where it left off.
      */
-    private function __construct(private Peekable $tokens, private Declarations $declarations)
+    private readonly TypeParser $typeParser;
+
+    private function __construct(private readonly Tokens $tokens, private readonly Declarations $declarations)
     {
+        $this->typeParser = new TypeParser($tokens);
     }
 
     public static function parse(string $expression, Declarations|Types|null $types = null): Expression
@@ -49,14 +51,7 @@ final class ExpressionParser
         if ($types instanceof Types) {
             $types = new Declarations($types);
         }
-        $declarations = $types;
-        $chars = $expression === '' ? [] : str_split($expression);
-        /**
-         * @infection-ignore-all Currently, there's no difference between str_split and its multibyte version. Multibyte
-         *     string literals and identifiers are just put back together. If you encounter a case where it does matter,
-         *     just change it to mb_str_split and add an appropriate test case.
-         */
-        return (new self(new Peekable(Tokenizer::tokenize($chars)), $declarations))->parseComplete();
+        return (new self(Tokens::of($expression), $types))->parseComplete();
     }
 
     public static function parseTyped(string $expression, Type $type, Declarations|Types|null $types = null): Expression
@@ -97,7 +92,7 @@ final class ExpressionParser
     private function parseOr(): Expression
     {
         $left = $this->parseAnd();
-        while ($this->nextToken() === Token::Or) {
+        while ($this->tokens->peekToken() === Token::Or) {
             $this->tokens->next();
             $left = $left->or_($this->parseAnd());
         }
@@ -111,7 +106,7 @@ final class ExpressionParser
     private function parseAnd(): Expression
     {
         $left = $this->parseComparison();
-        while ($this->nextToken() === Token::And) {
+        while ($this->tokens->peekToken() === Token::And) {
             $this->tokens->next();
             $left = $left->and_($this->parseComparison());
         }
@@ -130,7 +125,7 @@ final class ExpressionParser
     private function parseComparison(): Expression
     {
         $left = $this->parseAdditive();
-        $build = match ($this->nextToken()) {
+        $build = match ($this->tokens->peekToken()) {
             Token::TripleEquals => $left->eq(...),
             Token::NotEquals => $left->neq(...),
             Token::CloseAngle => $left->gt(...),
@@ -153,7 +148,7 @@ final class ExpressionParser
     private function parseAdditive(): Expression
     {
         $left = $this->parseUnary();
-        while ($this->nextToken() === Token::Minus) {
+        while ($this->tokens->peekToken() === Token::Minus) {
             $this->tokens->next();
             $left = $left->subtract($this->parseUnary());
         }
@@ -186,7 +181,7 @@ final class ExpressionParser
     private function parsePostfix(): Expression
     {
         $expr = $this->parsePrimary();
-        while ($this->nextToken() === Token::Dot) {
+        while ($this->tokens->peekToken() === Token::Dot) {
             $expr = $this->dot($expr);
         }
         return $expr;
@@ -199,7 +194,7 @@ final class ExpressionParser
     {
         $parsedToken = $this->tokens->peek();
         if ($parsedToken === null) {
-            throw SyntaxError::create('Expected expression, got end of input', $this->nextSpan());
+            throw $this->tokens->expected('expression');
         }
         $token = $parsedToken->token;
         if ($token === 'true') {
@@ -230,10 +225,7 @@ final class ExpressionParser
         if ($token === Token::OpenParen) {
             return $this->group();
         }
-        throw SyntaxError::create(
-            sprintf('Expected expression, got %s', Token::print($token)),
-            $parsedToken->location(),
-        );
+        throw $this->tokens->expected('expression');
     }
 
     /**
@@ -246,9 +238,9 @@ final class ExpressionParser
      */
     private function group(): Expression
     {
-        $this->expect(Token::OpenParen);
+        $this->tokens->expect(Token::OpenParen);
         $inner = $this->parseExpression();
-        $this->expect(Token::CloseParen);
+        $this->tokens->expect(Token::CloseParen);
         return $inner;
     }
 
@@ -261,7 +253,7 @@ final class ExpressionParser
     private function variable(string $name, Span $start): Get
     {
         $declaredType = $this->declarations->variables[$name] ?? null;
-        if ($this->nextToken() !== Token::Colon) {
+        if ($this->tokens->peekToken() !== Token::Colon) {
             if ($declaredType !== null) {
                 return Expr::get($name, new TypeHint($declaredType, false), $start);
             }
@@ -270,17 +262,8 @@ final class ExpressionParser
                 $start,
             );
         }
-        $this->expect(Token::Colon);
-        $typeNode = TypeParser::parse($this->tokens);
-        if ($typeNode === null) {
-            throw SyntaxError::create('Expected type, got end of string', $this->nextSpan());
-        }
-        if ($typeNode instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected type, got %s', Token::print($typeNode->token)),
-                $typeNode->location(),
-            );
-        }
+        $this->tokens->expect(Token::Colon);
+        $typeNode = $this->typeParser->type();
         $type = $this->declarations->types->resolve($typeNode);
         if ($type instanceof TypeError) {
             throw $type;
@@ -299,73 +282,27 @@ final class ExpressionParser
         return Expr::get($name, $type, $start->to($typeNode->location));
     }
 
-    private function expect(Token $expected): ParsedToken
-    {
-        $actual = $this->tokens->peek();
-        if ($actual === null) {
-            $previousToken = $this->tokens->previous();
-            assert($previousToken !== null);
-            $span = Span::char($previousToken->line, $previousToken->column + 1);
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', Token::print($expected)), $span);
-        }
-        if ($actual->token === $expected) {
-            $this->tokens->next();
-            return $actual;
-        }
-        throw SyntaxError::create(
-            sprintf('Expected %s, got %s', Token::print($expected), Token::print($actual->token)),
-            $actual->location(),
-        );
-    }
-
-    /**
-     * The body of every bracketed, comma-separated list in the language: call arguments, list items, struct fields and
-     * lambda parameters.
-     *
-     * A trailing comma is allowed. A missing one simply ends the list, which leaves the caller's expect($close) to
-     * report the token that isn't a comma.
-     *
-     * @template T
-     * @param callable(): T $parseItem
-     * @return list<T>
-     */
-    private function parseCommaSeparated(Token $close, callable $parseItem): array
-    {
-        $items = [];
-        while (true) {
-            $token = $this->nextToken();
-            if ($token === null || $token === $close) {
-                return $items;
-            }
-            $items[] = $parseItem();
-            if ($this->nextToken() !== Token::Comma) {
-                return $items;
-            }
-            $this->tokens->next();
-        }
-    }
-
     /**
      * |one, two, three, | item:string === needle:string
      * =================================================
      */
     private function lambda(): Expression
     {
-        $start = $this->expect(Token::Pipe);
-        $params = $this->parseCommaSeparated(
+        $start = $this->tokens->expect(Token::Pipe);
+        $params = $this->tokens->commaSeparated(
             Token::Pipe,
-            fn(): string => $this->expectIdentifier('parameter name')[0],
+            fn(): string => $this->tokens->expectIdentifier('parameter name')[0],
         );
-        $this->expect(Token::Pipe);
+        $this->tokens->expect(Token::Pipe);
         $body = $this->parseExpression();
         return Expr::lambda($body, $params, $start->location()->to($body->location()));
     }
 
     private function dot(Expression $target): Call|FieldAccess
     {
-        $this->expect(Token::Dot);
-        [$name, $nameLocation] = $this->expectIdentifier('function name');
-        $token = $this->nextToken();
+        $this->tokens->expect(Token::Dot);
+        [$name, $nameLocation] = $this->tokens->expectIdentifier('function name');
+        $token = $this->tokens->peekToken();
         return match ($token) {
             Token::Colon, Token::OpenParen => $this->call($name, $nameLocation, $target),
             default => Expr::fieldAccess($target, $name, $target->location()->to($nameLocation)),
@@ -380,9 +317,9 @@ final class ExpressionParser
     {
         $signature = $this->declarations->functions[$name] ?? null;
         $returnType = $this->returnType();
-        $this->expect(Token::OpenParen);
-        $args = $this->parseCommaSeparated(Token::CloseParen, $this->parseExpression(...));
-        $closeParen = $this->expect(Token::CloseParen);
+        $this->tokens->expect(Token::OpenParen);
+        $args = $this->tokens->commaSeparated(Token::CloseParen, $this->parseExpression(...));
+        $closeParen = $this->tokens->expect(Token::CloseParen);
         return Expr::call(
             $target,
             $name,
@@ -404,20 +341,11 @@ final class ExpressionParser
      */
     private function returnType(): TypeAnnotation|null
     {
-        if ($this->nextToken() !== Token::Colon) {
+        if ($this->tokens->peekToken() !== Token::Colon) {
             return null;
         }
-        $this->expect(Token::Colon);
-        $typeNode = TypeParser::parse($this->tokens);
-        if ($typeNode === null) {
-            throw SyntaxError::create('Expected type after colon', $this->nextSpan());
-        }
-        if ($typeNode instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected type after colon, got %s', Token::print($typeNode->token)),
-                $typeNode->location(),
-            );
-        }
+        $this->tokens->expect(Token::Colon);
+        $typeNode = $this->typeParser->type('return type');
         $returnType = $this->declarations->types->resolve($typeNode);
         if ($returnType instanceof TypeError) {
             throw $returnType;
@@ -426,53 +354,14 @@ final class ExpressionParser
     }
 
     /**
-     * @return array{string, Span}
-     */
-    private function expectIdentifier(string $expected): array
-    {
-        $name = $this->tokens->peek();
-        if ($name === null) {
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', $expected), $this->nextSpan());
-        }
-        if (!is_string($name->token)) {
-            throw SyntaxError::create(
-                sprintf('Expected %s, got %s', $expected, Token::print($name->token)),
-                $name->location(),
-            );
-        }
-        $this->tokens->next();
-        return [$name->token, $name->location()];
-    }
-
-    /**
-     * The token the parser is looking at, or null at the end of the input.
-     *
-     * @return Token | string | Literal<string | int | float | bool> | null
-     */
-    private function nextToken(): Token|string|Literal|null
-    {
-        return $this->tokens->peek()?->token;
-    }
-
-    private function nextSpan(): Span
-    {
-        $token = $this->tokens->peek();
-        if ($token !== null) {
-            return Span::char($token->line, $token->column);
-        }
-        $previous = $this->tokens->previous();
-        return $previous === null ? Span::char(1, 1) : Span::char($previous->line, $previous->column + 1);
-    }
-
-    /**
      * [1 - 2, foo:int]
      * ================
      */
     private function parseListLiteral(): ListLiteral
     {
-        $start = $this->expect(Token::OpenBracket);
-        $items = $this->parseCommaSeparated(Token::CloseBracket, $this->parseExpression(...));
-        $close = $this->expect(Token::CloseBracket);
+        $start = $this->tokens->expect(Token::OpenBracket);
+        $items = $this->tokens->commaSeparated(Token::CloseBracket, $this->parseExpression(...));
+        $close = $this->tokens->expect(Token::CloseBracket);
         return Expr::listLiteral($items, $start->location()->to($close->location()));
     }
 
@@ -482,12 +371,13 @@ final class ExpressionParser
      */
     private function parseStructLiteral(): StructLiteral
     {
-        $start = $this->expect(Token::OpenBrace);
+        $start = $this->tokens->expect(Token::OpenBrace);
         $fields = [];
-        foreach ($this->parseCommaSeparated(Token::CloseBrace, $this->parseStructField(...)) as [$name, $value]) {
+        $parsed = $this->tokens->commaSeparated(Token::CloseBrace, $this->parseStructField(...));
+        foreach ($parsed as [$name, $value]) {
             $fields[$name] = $value;
         }
-        $close = $this->expect(Token::CloseBrace);
+        $close = $this->tokens->expect(Token::CloseBrace);
         return Expr::structLiteral($fields, $start->location()->to($close->location()));
     }
 
@@ -499,8 +389,8 @@ final class ExpressionParser
      */
     private function parseStructField(): array
     {
-        [$name] = $this->expectIdentifier('field name');
-        $this->expect(Token::Colon);
+        [$name] = $this->tokens->expectIdentifier('field name');
+        $this->tokens->expect(Token::Colon);
         return [$name, $this->parseExpression()];
     }
 }

--- a/src/Parser/ParsedToken.php
+++ b/src/Parser/ParsedToken.php
@@ -4,27 +4,23 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck\Parser;
 
-use function assert;
-use function strlen;
-
 final class ParsedToken
 {
     /**
      * @param Token | string | Literal<string | int | float | bool> $token
-     * @param positive-int $line
-     * @param positive-int $column
+     * @param Span $location Where the token is written, as wide as it is written. Handed in by {@see Tokenizer},
+     *     which is scanning the source and is the only thing that knows: a token does not remember its spelling, so
+     *     the extent cannot be worked back out of it. `007` and `1.50` are the same tokens as `7` and `1.5`, and
+     *     measuring how they print would put the end of the first one two columns short of where it is written.
      */
     public function __construct(
         public readonly Token|string|Literal $token,
-        public readonly int $line,
-        public readonly int $column,
+        private readonly Span $location,
     ) {
     }
 
     public function location(): Span
     {
-        $str = $this->token instanceof Token ? $this->token->value : (string)$this->token;
-        assert($str !== '');
-        return new Span($this->line, $this->column, $this->line, $this->column + strlen($str) - 1);
+        return $this->location;
     }
 }

--- a/src/Parser/Peekable.php
+++ b/src/Parser/Peekable.php
@@ -20,7 +20,7 @@ use function count;
  * never arrived, so the stream is short one item rather than at its end, and it says so however often it is asked.
  *
  * The cursor only moves where it's told; deciding when a reading has failed, and rewinding if it has, is the caller's
- * business. See {@see TypeParser::tryTypeArguments()} for the one place that does.
+ * business.
  *
  * @template T
  * @internal
@@ -62,9 +62,14 @@ final class Peekable
     }
 
     /**
+     * Impure, though it looks like a plain read: it is what pulls from the generator, so a call whose result is
+     * thrown away still buffers an item, still runs whatever the generator does to produce it, and still throws if
+     * that fails. Two calls agree only while the cursor stays put.
+     *
      * @param non-negative-int $ahead How far past the next item to look: peek() shows the next item, peek(1) the one
      *     after it.
      * @return T | null
+     * @phpstan-impure
      */
     public function peek(int $ahead = 0): mixed
     {

--- a/src/Parser/Position.php
+++ b/src/Parser/Position.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Parser;
+
+/**
+ * Where a single character sits in the source text.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Position
+{
+    /**
+     * @param positive-int $line
+     * @param positive-int $column
+     */
+    public function __construct(public readonly int $line, public readonly int $column)
+    {
+    }
+
+    /**
+     * The extent of the one character at this position.
+     */
+    public function span(): Span
+    {
+        return Span::char($this->line, $this->column);
+    }
+}

--- a/src/Parser/Source.php
+++ b/src/Parser/Source.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Parser;
+
+/**
+ * The characters of an expression, and where in it the reader stands.
+ *
+ * A scanner reads through {@see self::take()} and never touches a line or column of its own, so there is exactly one
+ * statement of what moving past a character means—{@see self::take()}'s newline rule—and a scanner cannot get it wrong
+ * by forgetting it. A string literal crossing a line is handled by construction rather than by a branch that repeats
+ * the rule.
+ *
+ * Positions are read, not computed: {@see self::position()} is where the next character will be read, and
+ * {@see self::spanFrom()} ends a token at the last character actually taken, so no caller has to reconstruct an end
+ * from a cursor that has already moved past it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Source
+{
+    /** @var Peekable<string> */
+    private readonly Peekable $chars;
+    /** @var positive-int */
+    private int $line = 1;
+    /** @var positive-int */
+    private int $column = 1;
+    /**
+     * Where the character most recently taken was written. A token's extent ends there, so it survives the cursor
+     * moving on. Before anything is taken it is the start of the input, which is where the cursor is anyway.
+     *
+     * @var positive-int
+     */
+    private int $takenLine = 1;
+    /** @var positive-int */
+    private int $takenColumn = 1;
+
+    /**
+     * @param iterable<mixed, string> $chars
+     */
+    public function __construct(iterable $chars)
+    {
+        $this->chars = new Peekable($chars);
+    }
+
+    /**
+     * @param non-negative-int $ahead How far past the next character to look: peek() shows the next one, peek(1) the
+     *     one after it.
+     * @phpstan-impure
+     */
+    public function peek(int $ahead = 0): string|null
+    {
+        return $this->chars->peek($ahead);
+    }
+
+    /**
+     * Reads the next character and moves past it. The only place that knows a newline starts a line and everything
+     * else widens one.
+     *
+     * @phpstan-impure
+     */
+    public function take(): string|null
+    {
+        $char = $this->chars->next();
+        if ($char === null) {
+            return null;
+        }
+        $this->takenLine = $this->line;
+        $this->takenColumn = $this->column;
+        if ($char === "\n") {
+            $this->line++;
+            $this->column = 1;
+        } else {
+            $this->column++;
+        }
+        return $char;
+    }
+
+    /**
+     * Where the next character will be read—the start of a token that has not been scanned yet.
+     */
+    public function position(): Position
+    {
+        return new Position($this->line, $this->column);
+    }
+
+    /**
+     * The extent of everything taken since $start, ending on the last character taken rather than on the one that
+     * stopped the scan.
+     */
+    public function spanFrom(Position $start): Span
+    {
+        return new Span($start->line, $start->column, $this->takenLine, $this->takenColumn);
+    }
+}

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck\Parser;
 
-use function assert;
 use function ctype_space;
 use function is_numeric;
 use function ord;
@@ -27,101 +26,92 @@ final class Tokenizer
     private const UNDERSCORE = 95;
 
     /**
+     * A token is whatever a scanner reads, spanning from where the scan started to the last character it took. That is
+     * said once, here, so it cannot be said differently by the next token form added: a scanner returns what it read
+     * and never sees the span it will be given. No scanner keeps a line or column of its own either, so none of them
+     * can disagree about what reading a character does—see {@see Source}.
+     *
      * @param iterable<mixed, string> $chars
      * @return iterable<ParsedToken>
      */
     public static function tokenize(iterable $chars): iterable
     {
-        /** @var positive-int $line */
-        $line = 1;
-        /** @var positive-int $column */
-        $column = 1;
-        $chars = new Peekable($chars);
-        while (true) {
-            $char = $chars->peek();
-            if ($char === null) {
-                break;
-            }
-            $singleCharToken = match ($char) {
-                '.' => Token::Dot,
-                '(' => Token::OpenParen,
-                ')' => Token::CloseParen,
-                ':' => Token::Colon,
-                ',' => Token::Comma,
-                '[' => Token::OpenBracket,
-                ']' => Token::CloseBracket,
-                '{' => Token::OpenBrace,
-                '}' => Token::CloseBrace,
-                default => null,
-            };
-            if ($singleCharToken !== null) {
-                $chars->next();
-                yield new ParsedToken($singleCharToken, $line, $column);
-                $column++;
-                continue;
-            }
+        $source = new Source($chars);
+        while (($char = $source->peek()) !== null) {
             if (ctype_space($char)) {
-                $chars->next();
-                if ($char === "\n") {
-                    $line++;
-                    $column = 1;
-                } else {
-                    $column++;
-                }
+                $source->take();
                 continue;
             }
-            if ($char === '"') {
-                $startLine = $line;
-                $startCol = $column;
-                $chars->next();
-                $column++;
-                yield new ParsedToken(self::string($chars, $line, $column), $startLine, $startCol);
-                continue;
-            }
-            $startCol = $column;
-            $multiCharToken = match ($char) {
-                '=' => self::exact($chars, $line, $column, '===', Token::TripleEquals),
-                '!' => self::exact($chars, $line, $column, '!==', Token::NotEquals),
-                '&' => self::exact($chars, $line, $column, '&&', Token::And),
-                '<' => self::angle($chars, $column, Token::OpenAngle, Token::LessThanEquals),
-                '>' => self::angle($chars, $column, Token::CloseAngle, Token::GreaterThanEquals),
-                /**
-                 * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
-                 * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one.
-                 * If the sign were folded in here, whitespace would silently decide the meaning of `a -2`:
-                 * subtraction, or `a` followed by the literal -2.
-                 */
-                '-' => self::bareOrPair($chars, $column, '>', Token::Minus, Token::Arrow),
-                '|' => self::bareOrPair($chars, $column, '|', Token::Pipe, Token::Or),
-                default => null,
-            };
-            if ($multiCharToken !== null) {
-                yield new ParsedToken($multiCharToken, $line, $startCol);
-                continue;
-            }
-            if (is_numeric($char)) {
-                yield new ParsedToken(self::number($chars, $column), $line, $startCol);
-                continue;
-            }
-            if (self::isIdentifierChar($char, first: true)) {
-                yield new ParsedToken(self::identifier($chars, $line, $column), $line, $startCol);
-                continue;
-            }
-            throw SyntaxError::create(sprintf('Unexpected character %s', $char), Span::char($line, $column));
+            $start = $source->position();
+            yield new ParsedToken(self::scan($source, $char), $source->spanFrom($start));
         }
     }
 
     /**
-     * @param Peekable<string> $chars
-     * @param positive-int $line
-     * @param positive-int $column
+     * Which token starts with $char, and reading it. Every branch leaves the source just past the token it read and
+     * says nothing about where that was; {@see self::tokenize()} measures. The character is peeked, not taken, so a
+     * branch is free to take it wherever suits the form it reads—in the dispatch for the one-character tokens, inside
+     * the scanner for the operators, in the scanning loop for numbers and identifiers.
+     *
+     * @return Token | string | Literal<string | int | float>
      */
-    private static function identifier(Peekable $chars, int $line, int &$column): string
+    private static function scan(Source $source, string $char): Token|string|Literal
+    {
+        $singleCharToken = match ($char) {
+            '.' => Token::Dot,
+            '(' => Token::OpenParen,
+            ')' => Token::CloseParen,
+            ':' => Token::Colon,
+            ',' => Token::Comma,
+            '[' => Token::OpenBracket,
+            ']' => Token::CloseBracket,
+            '{' => Token::OpenBrace,
+            '}' => Token::CloseBrace,
+            default => null,
+        };
+        if ($singleCharToken !== null) {
+            $source->take();
+            return $singleCharToken;
+        }
+        if ($char === '"') {
+            $source->take();
+            return self::string($source);
+        }
+        $multiCharToken = match ($char) {
+            '=' => self::exact($source, '===', Token::TripleEquals),
+            '!' => self::exact($source, '!==', Token::NotEquals),
+            '&' => self::exact($source, '&&', Token::And),
+            '<' => self::angle($source, Token::OpenAngle, Token::LessThanEquals),
+            '>' => self::angle($source, Token::CloseAngle, Token::GreaterThanEquals),
+            /**
+             * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
+             * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one.
+             * If the sign were folded in here, whitespace would silently decide the meaning of `a -2`:
+             * subtraction, or `a` followed by the literal -2.
+             */
+            '-' => self::bareOrPair($source, '>', Token::Minus, Token::Arrow),
+            '|' => self::bareOrPair($source, '|', Token::Pipe, Token::Or),
+            default => null,
+        };
+        if ($multiCharToken !== null) {
+            return $multiCharToken;
+        }
+        if (is_numeric($char)) {
+            return self::number($source);
+        }
+        if (self::isIdentifierChar($char, first: true)) {
+            return self::identifier($source);
+        }
+        // Nothing has been taken, so the character that has no reading is still the one under the cursor.
+        throw SyntaxError::create(sprintf('Unexpected character %s', $char), $source->position()->span());
+    }
+
+    private static function identifier(Source $source): string
     {
         $identifier = '';
 
         while (true) {
-            $char = $chars->peek();
+            $char = $source->peek();
 
             if ($char === null) {
                 break;
@@ -134,8 +124,7 @@ final class Tokenizer
             }
 
             $identifier .= $char;
-            $chars->next();
-            $column++;
+            $source->take();
         }
 
         return $identifier;
@@ -146,28 +135,23 @@ final class Tokenizer
      * first character is there, the whole sequence is required; anything short of it is an error naming the operator
      * that was expected and underlining the characters that were actually read.
      *
-     * @param Peekable<string> $chars
-     * @param positive-int $line
-     * @param positive-int $column
      * @param non-empty-string $sequence
      */
-    private static function exact(Peekable $chars, int $line, int &$column, string $sequence, Token $token): Token
+    private static function exact(Source $source, string $sequence, Token $token): Token
     {
-        $startColumn = $column;
+        $start = $source->position();
         $read = '';
         foreach (str_split($sequence) as $char) {
-            if ($chars->peek() !== $char) {
-                $endColumn = $column - 1;
-                // The main loop only dispatches here after peeking $sequence's first character, so that one matched.
-                assert($endColumn >= 1);
+            if ($source->peek() !== $char) {
+                // The main loop only dispatches here after peeking $sequence's first character, so that one matched
+                // and was taken: the span always covers at least it.
                 throw SyntaxError::create(
                     sprintf('Expected %s, got %s', $sequence, $read),
-                    new Span($line, $startColumn, $line, $endColumn),
+                    $source->spanFrom($start),
                 );
             }
             $read .= $char;
-            $chars->next();
-            $column++;
+            $source->take();
         }
         return $token;
     }
@@ -178,19 +162,14 @@ final class Tokenizer
      * operators `<=` and `>=`. The pair reading wins with one exception: two `=` after the angle mean a `===` follows,
      * as in `foo:list<int>===bar`, so the angle stays bare instead of stealing the first `=` and leaving behind a `==`
      * that is no token at all.
-     *
-     * @param Peekable<string> $chars
-     * @param positive-int $column
      */
-    private static function angle(Peekable $chars, int &$column, Token $bare, Token $pair): Token
+    private static function angle(Source $source, Token $bare, Token $pair): Token
     {
-        $chars->next();
-        $column++;
-        if ($chars->peek() !== '=' || $chars->peek(1) === '=') {
+        $source->take();
+        if ($source->peek() !== '=' || $source->peek(1) === '=') {
             return $bare;
         }
-        $chars->next();
-        $column++;
+        $source->take();
         return $pair;
     }
 
@@ -200,64 +179,54 @@ final class Tokenizer
      * followed by a `>`. For `||` it's a choice: the two bars could also be the empty parameter list of a lambda, so
      * that list is written `| |`, and glued bars are the or they almost always are.
      *
-     * @param Peekable<string> $chars
-     * @param positive-int $column
      * @param non-empty-string $second The character that, if it comes next, makes this $pair instead of $bare.
      */
-    private static function bareOrPair(Peekable $chars, int &$column, string $second, Token $bare, Token $pair): Token
+    private static function bareOrPair(Source $source, string $second, Token $bare, Token $pair): Token
     {
-        $chars->next();
-        $column++;
-        if ($chars->peek() !== $second) {
+        $source->take();
+        if ($source->peek() !== $second) {
             return $bare;
         }
-        $chars->next();
-        $column++;
+        $source->take();
         return $pair;
     }
 
     /**
-     * @param Peekable<string> $chars
-     * @param positive-int $column
      * @return Literal<int | float>
      */
-    private static function number(Peekable $chars, int &$column): Literal
+    private static function number(Source $source): Literal
     {
         $number = '';
         while (true) {
-            $char = $chars->peek();
+            $char = $source->peek();
             if ($char === null || !is_numeric($number . $char)) {
                 break;
             }
             $number .= $char;
-            $chars->next();
-            $column++;
+            $source->take();
         }
         return new Literal(str_contains($number, '.') ? (float)$number : (int)$number);
     }
 
     /**
-     * @param Peekable<string> $chars
-     * @param positive-int $line
-     * @param positive-int $column
+     * A string literal is the only token that may contain a real newline. Nothing here says so: the source counts
+     * lines as it is read, so a literal that spans several of them ends where it ends, and every token after it is
+     * still reported on the line it is written on.
+     *
      * @return Literal<string>
      */
-    private static function string(Peekable $chars, int $line, int &$column): Literal
+    private static function string(Source $source): Literal
     {
         $string = '';
         while (true) {
-            $char = $chars->peek();
+            $char = $source->take();
             if ($char === null) {
-                throw SyntaxError::create('Expected closing quote', Span::char($line, $column));
+                throw SyntaxError::create('Expected closing quote', $source->position()->span());
             }
             if ($char === '"') {
-                $chars->next();
-                $column++;
                 break;
             }
             $string .= $char;
-            $chars->next();
-            $column++;
         }
         return new Literal($string);
     }

--- a/src/Parser/Tokens.php
+++ b/src/Parser/Tokens.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Parser;
+
+use function is_string;
+use function sprintf;
+use function str_split;
+
+/**
+ * The stream of tokens a parser reads, and the reading conventions {@see ExpressionParser} and {@see TypeParser} share:
+ * what it means to require something, where the input ran out, and the shape of every list in the language. Both walk
+ * the same stream, so both had private copies of these; one copy is what keeps the two from drifting apart as either is
+ * edited.
+ *
+ * Requiring something is stated once by {@see self::expected()} and not just for tokens: a type and an expression are
+ * required in the same words and blamed on the same span as a closing bracket, so the two parsers cannot word or locate
+ * the same complaint differently.
+ *
+ * The cursor underneath is a {@see Peekable}, which buffers whatever it is given and knows nothing about tokens—the
+ * tokenizer reads characters through one of its own. Everything token-shaped lives here instead, so a parser holds a
+ * stream that is already of tokens rather than one it has to keep saying is. It also only holds the part of the cursor
+ * a parser has any business with: looking behind is needed to say where the input ran out and nowhere else, so
+ * {@see Peekable::previous()} is not forwarded and {@see self::endOfInput()} is the one place that calls it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck\Parser
+ */
+final class Tokens
+{
+    /**
+     * @param Peekable<ParsedToken> $tokens
+     */
+    private function __construct(private readonly Peekable $tokens)
+    {
+    }
+
+    public static function of(string $source): self
+    {
+        /**
+         * @infection-ignore-all Currently, there's no difference between str_split and its multibyte version. Multibyte
+         *     string literals and identifiers are just put back together. If you encounter a case where it does matter,
+         *     just change it to mb_str_split and add an appropriate test case.
+         */
+        $chars = $source === '' ? [] : str_split($source);
+        return new self(new Peekable(Tokenizer::tokenize($chars)));
+    }
+
+    /**
+     * The token the parser is looking at, or null at the end of the input. Impure for the reason
+     * {@see Peekable::peek()} is: it is the read that scans the token.
+     *
+     * @phpstan-impure
+     */
+    public function peek(): ParsedToken|null
+    {
+        return $this->tokens->peek();
+    }
+
+    /**
+     * Just which token it is, for deciding what to parse next: that decision never depends on where the token is, and
+     * asking for only what it turns on keeps the location out of the conditions.
+     *
+     * @return Token | string | Literal<string | int | float | bool> | null
+     * @phpstan-impure
+     */
+    public function peekToken(): Token|string|Literal|null
+    {
+        return $this->tokens->peek()?->token;
+    }
+
+    /**
+     * Advances past the token the parser is looking at. Nothing is returned: every caller has already peeked the token
+     * it is stepping over, so handing it back again would only be a second way to say what it is.
+     */
+    public function next(): void
+    {
+        $this->tokens->next();
+    }
+
+    /**
+     * The current position, to be handed back to {@see self::restore()}.
+     *
+     * @return non-negative-int
+     */
+    public function snapshot(): int
+    {
+        return $this->tokens->snapshot();
+    }
+
+    /**
+     * @param non-negative-int $snapshot
+     */
+    public function restore(int $snapshot): void
+    {
+        $this->tokens->restore($snapshot);
+    }
+
+    /**
+     * Something was required here and isn't there. One rule with one span policy—blame the token that turned up, or
+     * where the input ran out if none did—so every reading that requires something says so through this rather than
+     * wording and locating its own complaint. What is required needn't be a single token: `type` and `expression` are
+     * asked for the same way `)` is, and are named the same way in the error.
+     *
+     * @param string $what What was required, as the error should name it: a printed token, or a phrase like
+     *     "field name" or "return type".
+     */
+    public function expected(string $what): SyntaxError
+    {
+        $actual = $this->tokens->peek();
+        return SyntaxError::create(
+            $actual === null
+                ? sprintf('Expected %s, got end of input', $what)
+                : sprintf('Expected %s, got %s', $what, Token::print($actual->token)),
+            $actual?->location() ?? $this->endOfInput(),
+        );
+    }
+
+    public function expect(Token $expected): ParsedToken
+    {
+        $actual = $this->tokens->peek();
+        if ($actual === null || $actual->token !== $expected) {
+            throw $this->expected(Token::print($expected));
+        }
+        $this->tokens->next();
+        return $actual;
+    }
+
+    /**
+     * @param string $expected What to call the identifier in the error, e.g. "field name".
+     * @return array{string, Span}
+     */
+    public function expectIdentifier(string $expected): array
+    {
+        $name = $this->tokens->peek();
+        if ($name === null || !is_string($name->token)) {
+            throw $this->expected($expected);
+        }
+        $this->tokens->next();
+        return [$name->token, $name->location()];
+    }
+
+    /**
+     * The body of every bracketed, comma-separated list in the language: type arguments, function parameter types,
+     * struct fields—both the type and the literal—call arguments, list items and lambda parameters.
+     *
+     * A trailing comma is allowed. A missing one simply ends the list, which leaves the caller's expect($close) to
+     * report the token that isn't a comma. Ending on the missing comma rather than on something that can't start
+     * another element is what lets an unclosed list be blamed on the bracket it needs instead of on whatever follows:
+     * `fn(int -> string` asks for the `)`, because the list stopped at a token that wasn't a comma without ever having
+     * to decide whether `->` could begin a parameter. Nothing here knows what an element looks like, so no element can
+     * be added that this has to be taught about.
+     *
+     * That holds from the second element on. The first has no comma before it to be missing, so a list that is neither
+     * empty nor already closed has no choice but to try to read one, and whatever $parseItem makes of the tokens there
+     * is what gets reported: `list<:` is blamed on the `:` that can't start a type, not on the `>` it is also missing.
+     *
+     * The loop ends because $parseItem either consumes a token or throws: a reading that could return having consumed
+     * nothing would leave the stream where it was, and the same token would be read as an element forever.
+     *
+     * @template T
+     * @param Token $close The bracket that ends the list, which the caller takes.
+     * @param callable(): T $parseItem
+     * @return list<T>
+     */
+    public function commaSeparated(Token $close, callable $parseItem): array
+    {
+        $items = [];
+        while (true) {
+            $token = $this->peekToken();
+            if ($token === null || $token === $close) {
+                return $items;
+            }
+            $items[] = $parseItem();
+            if ($this->peekToken() !== Token::Comma) {
+                return $items;
+            }
+            $this->tokens->next();
+        }
+    }
+
+    /**
+     * Where the input ran out: just after the last token read, or the very start of it if there never was one. Just
+     * after the token, that is, not just after the column it starts in—an input ending in `->` ran out two columns on,
+     * not one—which is the extent {@see ParsedToken::location()} carries. Carries rather than computes: the width of
+     * a token cannot be recovered from the token, only from the source, so an input ending in `1.50` ran out four
+     * columns on even though the literal prints back three wide.
+     */
+    public function endOfInput(): Span
+    {
+        $previous = $this->tokens->previous();
+        if ($previous === null) {
+            return Span::char(1, 1);
+        }
+        $end = $previous->location();
+        return Span::char($end->endLine, $end->endColumn + 1);
+    }
+}

--- a/src/Parser/TypeConstructor.php
+++ b/src/Parser/TypeConstructor.php
@@ -58,7 +58,7 @@ enum TypeConstructor: string
     /**
      * Whether a `<` directly after this name opens a type argument list. It does for the constructors that take at
      * least one, and for nothing else, which is what lets `a:int < b:int` read as a comparison: see
-     * {@see TypeParser::parse()}, which has to decide what the `<` is before there is a resolved type to ask.
+     * {@see TypeParser::type()}, which has to decide what the `<` is before there is a resolved type to ask.
      */
     public function takesTypeArguments(): bool
     {

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -5,36 +5,37 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck\Parser;
 
 use function array_merge;
-use function assert;
 use function is_string;
 use function sprintf;
-use function str_split;
 
 /**
- * @phpstan-type AnyToken Token | string | Literal<string | int | float>
+ * Reads types off a stream of tokens. Like {@see ExpressionParser}, it is an object over that stream rather than a set
+ * of statics passing it along: the stream never varies within a parse, so it is state, not an argument, and the
+ * recursive readings can hand each other a closure without one having to capture it.
+ *
+ * The expression parser holds one of these over the same stream, which is what lets a type appear inside an expression:
+ * both are readers of one stream that take turns.
+ *
  * @psalm-internal Eventjet\Ausdruck\Parser
  */
 final class TypeParser
 {
+    public function __construct(private readonly Tokens $tokens)
+    {
+    }
+
     /**
-     * A whole string is a whole type: unlike {@see self::parse()}, which reads one type off a stream the expression
+     * A whole string is a whole type: unlike {@see self::type()}, which reads one type off a stream the expression
      * parser keeps using afterwards, nothing here comes after the type, so a leftover token is an error rather than the
      * caller's business.
      */
     public static function parseString(string $str): TypeNode|SyntaxError
     {
-        $chars = $str === '' ? [] : str_split($str);
-        $tokens = new Peekable(Tokenizer::tokenize($chars));
+        $tokens = Tokens::of($str);
         try {
-            $node = self::parse($tokens);
+            $node = (new self($tokens))->type();
         } catch (SyntaxError $e) {
             return $e;
-        }
-        if ($node instanceof ParsedToken) {
-            return SyntaxError::create(sprintf('Expected type, got %s', Token::print($node->token)), $node->location());
-        }
-        if ($node === null) {
-            return SyntaxError::create('Invalid type ""', Span::char(1, 1));
         }
         $trailing = $tokens->peek();
         if ($trailing !== null) {
@@ -51,216 +52,143 @@ final class TypeParser
      */
     public static function parseDeclarations(string $src): array
     {
-        $tokens = new Peekable(Tokenizer::tokenize($src === '' ? [] : str_split($src)));
+        $tokens = Tokens::of($src);
+        $types = new self($tokens);
         $declarations = [];
-        while (($nameToken = $tokens->peek()) !== null) {
-            $name = $nameToken->token;
-            if (!is_string($name)) {
-                throw SyntaxError::create(
-                    sprintf('Expected type name, got %s', Token::print($name)),
-                    $nameToken->location(),
-                );
-            }
-            $tokens->next();
-            self::expect($tokens, Token::Colon);
-            $node = self::parse($tokens);
-            if ($node === null) {
-                throw SyntaxError::create(
-                    sprintf('Expected a type for %s, got end of input', $name),
-                    $nameToken->location(),
-                );
-            }
-            if (!$node instanceof TypeNode) {
-                throw SyntaxError::create(
-                    sprintf('Expected a type for %s, got %s', $name, Token::print($node->token)),
-                    $node->location(),
-                );
-            }
-            $declarations[$name] = $node;
+        while ($tokens->peek() !== null) {
+            [$name] = $tokens->expectIdentifier('type name');
+            $tokens->expect(Token::Colon);
+            // Named, because a declaration string holds several and the span alone leaves the reader counting them.
+            $declarations[$name] = $types->type(sprintf('type for %s', $name));
         }
         return $declarations;
     }
 
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * Reads one type off the stream. Everywhere a type may appear, one is required, so whether the tokens ahead are a
+     * type at all is settled here rather than handed back for each call site to decode and word its own complaint
+     * about. Lists of types don't have to ask either: {@see Tokens::commaSeparated()} ends on a missing comma, not on
+     * a token that can't start an element, so a type form added here needs no telling anywhere else.
+     *
+     * @param string $expected What to call the type in the error, e.g. "return type"—the same courtesy
+     *     {@see Tokens::expectIdentifier()} extends to names. A call site with nothing more specific to say than
+     *     "type" says nothing.
      */
-    public static function parse(Peekable $tokens): TypeNode|ParsedToken|null
+    public function type(string $expected = 'type'): TypeNode
     {
-        $parsedToken = $tokens->peek();
+        $parsedToken = $this->tokens->peek();
         if ($parsedToken === null) {
-            return null;
+            throw $this->tokens->expected($expected);
         }
         if ($parsedToken->token === Token::OpenBrace) {
-            return self::parseStruct($tokens);
+            return $this->parseStruct($parsedToken->location());
         }
         $name = $parsedToken->token;
         if (!is_string($name)) {
-            return $parsedToken;
+            throw $this->tokens->expected($expected);
         }
-        $tokens->next();
+        $location = $parsedToken->location();
+        $this->tokens->next();
         if ($name === 'fn') {
-            return self::parseFunction($tokens, $parsedToken->location());
+            return $this->parseFunction($location);
         }
-        if ($tokens->peek()?->token !== Token::OpenAngle) {
-            return new TypeNode($name, [], $parsedToken->location());
+        if ($this->tokens->peekToken() !== Token::OpenAngle) {
+            return new TypeNode($name, [], $location);
         }
         if (TypeConstructor::tryFrom($name)?->takesTypeArguments() ?? false) {
             // A generic constructor is committed: the `<` can only be its argument list, so whatever goes wrong in
-            // there is a genuine error, reported where it happens rather than rewound.
-            $tokens->next();
-            $args = self::parseTypeList($tokens);
+            // there is a genuine error, reported where it happens rather than rewound—unless a speculative list
+            // further out is still deciding and swallows it. See self::tryTypeArguments().
+            $this->tokens->next();
+            $args = $this->parseTypeList(Token::CloseAngle);
         } else {
             // Any other name might be an operand rather than a type constructor, and the `<` a less-than: `a:int <
             // b:int` is a comparison. Only a list that parses and closes is a type argument list, so try to read one
             // and hand the `<` back if that isn't what's there. A closed list after a name that takes none
             // (`int<string>`) is read as a type on purpose, so the resolver can reject it by name.
-            $args = self::tryTypeArguments($tokens);
+            $args = $this->tryTypeArguments();
             if ($args === null) {
-                return new TypeNode($name, [], $parsedToken->location());
+                return new TypeNode($name, [], $location);
             }
         }
-        $closeAngle = self::expect($tokens, Token::CloseAngle);
-        return new TypeNode($name, $args, $parsedToken->location()->to($closeAngle->location()));
+        $closeAngle = $this->tokens->expect(Token::CloseAngle);
+        return new TypeNode($name, $args, $location->to($closeAngle->location()));
     }
 
     /**
      * Reads a `<...>` type argument list, stopping on its `>` so the caller can take it. Returns null—leaving the
      * stream exactly where it was—if what follows isn't one after all. A {@see SyntaxError} raised along the way is
      * not an error to report: it only means these tokens aren't a type argument list either, and the caller is one
-     * that has some other reading of the `<` to fall back on. Anything already committed to a type argument list goes
-     * the direct route and lets its errors out.
+     * that has some other reading of the `<` to fall back on.
      *
-     * @param Peekable<ParsedToken> $tokens
+     * That goes for an error from a committed constructor nested inside, too. `MyType<list<int int>>` is blamed on its
+     * outer `<`, not on the comma missing from the inner list, because the reading fallen back to is a less-than, and
+     * it is `MyType < list<int int>>` that then has to make something of the tokens after it. Letting the innermost
+     * error out instead would be wrong wherever the fallback is what the writer meant: `a:MyType < list<int>` is a
+     * comparison, and the list in it closes only because the reading that rewound stopped looking. Telling those two
+     * apart means keeping the furthest failure across every reading tried and reporting that one once they have all
+     * failed—a way of choosing between errors this parser doesn't have.
+     *
      * @return list<TypeNode> | null
      */
-    private static function tryTypeArguments(Peekable $tokens): array|null
+    private function tryTypeArguments(): array|null
     {
-        $snapshot = $tokens->snapshot();
+        $snapshot = $this->tokens->snapshot();
         try {
-            $tokens->next();
-            $args = self::parseTypeList($tokens);
-            if ($tokens->peek()?->token === Token::CloseAngle) {
+            $this->tokens->next();
+            $args = $this->parseTypeList(Token::CloseAngle);
+            if ($this->tokens->peekToken() === Token::CloseAngle) {
                 return $args;
             }
         } catch (SyntaxError) {
         }
-        $tokens->restore($snapshot);
+        $this->tokens->restore($snapshot);
         return null;
     }
 
     /**
-     * map<int, string>
-     *     ===========
+     * The types inside a pair of brackets, wherever a type is written with several:
      *
-     * @param Peekable<ParsedToken> $tokens
+     *     map<int, string>        fn(int, string) -> bool
+     *         ===========            ===========
+     *
+     * @param Token $close The bracket that ends the list, which the caller takes.
      * @return list<TypeNode>
      */
-    private static function parseTypeList(Peekable $tokens): array
+    private function parseTypeList(Token $close): array
     {
-        $args = [];
-        while (true) {
-            $arg = self::parse($tokens);
-            if (!$arg instanceof TypeNode) {
-                break;
-            }
-            $args[] = $arg;
-            if ($tokens->peek()?->token === Token::Comma) {
-                $tokens->next();
-            }
-        }
-        return $args;
+        return $this->tokens->commaSeparated($close, fn(): TypeNode => $this->type());
     }
 
-    /**
-     * @param Peekable<ParsedToken> $tokens
-     * @param AnyToken $expected
-     */
-    private static function expect(Peekable $tokens, Token|string|Literal $expected): ParsedToken
+    private function parseFunction(Span $fnLocation): TypeNode
     {
-        $actual = $tokens->peek();
-        if ($actual === null) {
-            $previousToken = $tokens->previous();
-            assert($previousToken !== null);
-            $span = Span::char($previousToken->line, $previousToken->column + 1);
-            throw SyntaxError::create(sprintf('Expected %s, got end of input', Token::print($expected)), $span);
-        }
-        if ($actual->token === $expected) {
-            $tokens->next();
-            return $actual;
-        }
-        throw SyntaxError::create(
-            sprintf('Expected %s, got %s', Token::print($expected), Token::print($actual->token)),
-            $actual->location(),
-        );
-    }
-
-    /**
-     * @param Peekable<ParsedToken> $tokens
-     */
-    private static function parseFunction(Peekable $tokens, Span $fnLocation): TypeNode
-    {
-        self::expect($tokens, Token::OpenParen);
-        $params = self::parseTypeList($tokens);
-        self::expect($tokens, Token::CloseParen);
-        $arrow = self::expect($tokens, Token::Arrow);
-        $returnType = self::parse($tokens);
-        if ($returnType === null) {
-            throw SyntaxError::create('Expected return type, got end of input', $arrow->location());
-        }
-        if ($returnType instanceof ParsedToken) {
-            throw SyntaxError::create(
-                sprintf('Expected return type, got %s', Token::print($returnType->token)),
-                $returnType->location(),
-            );
-        }
+        $this->tokens->expect(Token::OpenParen);
+        $params = $this->parseTypeList(Token::CloseParen);
+        $this->tokens->expect(Token::CloseParen);
+        $this->tokens->expect(Token::Arrow);
+        $returnType = $this->type('return type');
         return new TypeNode('fn', array_merge($params, [$returnType]), $fnLocation->to($returnType->location));
     }
 
     /**
-     * @param Peekable<ParsedToken> $tokens
+     * @param Span $start The location of the `{`, which {@see self::type()} has already peeked.
      */
-    private static function parseStruct(Peekable $tokens): TypeNode
+    private function parseStruct(Span $start): TypeNode
     {
-        $openBraceToken = $tokens->peek();
-        assert($openBraceToken !== null);
-        $start = $openBraceToken->location();
-        $tokens->next();
-        $fields = [];
-        while (true) {
-            $nameToken = $tokens->peek();
-            if ($nameToken === null) {
-                break;
-            }
-            if ($nameToken->token === Token::CloseBrace) {
-                break;
-            }
-            $name = $nameToken->token;
-            if (!is_string($name)) {
-                throw SyntaxError::create(
-                    sprintf('Expected field name, got %s', Token::print($name)),
-                    $nameToken->location(),
-                );
-            }
-            $tokens->next();
-            self::expect($tokens, Token::Colon);
-            $type = self::parse($tokens);
-            if ($type === null) {
-                throw SyntaxError::create('Expected type, got end of input', $nameToken->location());
-            }
-            if (!$type instanceof TypeNode) {
-                throw SyntaxError::create(
-                    sprintf('Expected type, got %s', Token::print($type->token)),
-                    $type->location(),
-                );
-            }
-            $fields[] = TypeNode::keyValue(new TypeNode($name, [], $nameToken->location()), $type);
-            $token = $tokens->peek();
-            if ($token?->token !== Token::Comma) {
-                break;
-            }
-            $tokens->next();
-        }
-        $end = self::expect($tokens, Token::CloseBrace)->location();
+        $this->tokens->next();
+        $fields = $this->tokens->commaSeparated(Token::CloseBrace, fn(): TypeNode => $this->parseField());
+        $end = $this->tokens->expect(Token::CloseBrace)->location();
         return TypeNode::struct($fields, $start->to($end));
+    }
+
+    /**
+     * {name: string, age: int}
+     *  ============
+     */
+    private function parseField(): TypeNode
+    {
+        [$name, $nameLocation] = $this->tokens->expectIdentifier('field name');
+        $this->tokens->expect(Token::Colon);
+        return TypeNode::keyValue(new TypeNode($name, [], $nameLocation), $this->type());
     }
 }

--- a/src/Parser/Types.php
+++ b/src/Parser/Types.php
@@ -146,7 +146,7 @@ final class Types
 
     /**
      * An alias is a name for one complete type, so like the argument-less built-ins, it rejects type arguments instead
-     * of silently dropping them—`Foo<int>` is as invalid as `int<string>`. {@see TypeParser::parse()} counts on that:
+     * of silently dropping them—`Foo<int>` is as invalid as `int<string>`. {@see TypeParser::type()} counts on that:
      * it reads a closed argument list after any name and leaves rejecting it to this resolver.
      */
     private function resolveAlias(TypeNode $node): Type|TypeError|null

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -760,6 +760,21 @@ final class ExpressionParserTest extends TestCase
                 'x:fn(int) -> int &',
                 '                 =',
             ],
+            // A token is as wide as it is written, not as wide as it prints back. `1.50` and `007` are four and
+            // three columns wide, though they re-print as `1.5` and `7`; the extent is recorded while the source is
+            // being read, so neither the literal itself nor the end of the input after one lands short of where it is.
+            [
+                '[1, 1.50 2]',
+                '         = ',
+            ],
+            [
+                '[1, 2.50',
+                '        =',
+            ],
+            [
+                '[007',
+                '    =',
+            ],
         ];
         foreach ($cases as [$expression, $location]) {
             preg_match('/^(?<spaces> *)(?<underline>=+)/', $location, $matches);
@@ -781,6 +796,15 @@ final class ExpressionParserTest extends TestCase
                     === :string
                 EXPR,
             Span::char(2, 9),
+        ];
+        // A string literal is the one token that can contain a newline, so it is the one token that can end on a
+        // line it didn't start on. Everything after it is on the line it ended on, not the line it began on.
+        yield [
+            <<<'EXPR'
+                ["a
+                b", &]
+                EXPR,
+            Span::char(2, 5),
         ];
     }
 

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -415,8 +415,15 @@ final class ExpressionParserTest extends TestCase
         // Two `=` after a `>` keep the angle bare, whatever comes next (see the `foo:list<int>===bar` parse case), so
         // the `==` here is blamed as its own broken `===` rather than a `>=` eating its first `=`.
         yield 'greater-equals with an extra equals' => ['a:int >== 1', 'Expected ===, got =='];
-        yield 'end of string variable and colon' => ['foo:'];
-        yield 'end of string after function call and colon' => ['foo:string.substr:'];
+        // A colon promises a type, so running out after one asks for the type, not for whatever the colon was part of.
+        // The return type of a call is named as such; a variable's type has no name of its own to be called by.
+        yield 'end of string variable and colon' => ['foo:', 'Expected type, got end of input'];
+        yield 'non-type token after a variable colon' => ['foo:->', 'Expected type, got ->'];
+        yield 'non-type token after a call colon' => ['a:int.foo:->', 'Expected return type, got ->'];
+        yield 'end of string after function call and colon' => [
+            'foo:string.substr:',
+            'Expected return type, got end of input',
+        ];
         yield 'end of string after function dot' => ['foo:string.'];
         yield 'missing function name' => ['foo:string.:string()'];
         yield 'list literal: missing closing bracket' => ['[1, 2'];

--- a/tests/unit/Parser/TypeParserTest.php
+++ b/tests/unit/Parser/TypeParserTest.php
@@ -30,8 +30,16 @@ final class TypeParserTest extends TestCase
             'fn(int',
             'Expected ), got end of input',
         ];
+        // A type is required everywhere one may appear, so one message serves them all; where a position has a name of
+        // its own, it says that instead of just "type".
+        //
+        // The input ran out one column past the whole `->`, not one past the column it starts in: a token is as wide
+        // as it is written.
         yield 'End of string after function arrow' => [
-            'fn(int) ->',
+            <<<'AUSDRUCK'
+                fn(int) ->
+                          =
+                AUSDRUCK,
             'Expected return type, got end of input',
         ];
         yield 'Dot after function arrow' => [
@@ -40,14 +48,14 @@ final class TypeParserTest extends TestCase
         ];
         yield 'Empty string' => [
             <<<'AUSDRUCK'
-                
+
                 =
                 AUSDRUCK,
-            'Invalid type ""',
+            'Expected type, got end of input',
         ];
         yield 'Whitespace-only string' => [
             '  ',
-            'Invalid type ""',
+            'Expected type, got end of input',
         ];
         yield 'Arrow' => [
             <<<'AUSDRUCK'
@@ -65,7 +73,10 @@ final class TypeParserTest extends TestCase
             'Expected field name, got {',
         ];
         yield 'Struct: end of input after field name' => [
-            '{name',
+            <<<'AUSDRUCK'
+                {name
+                     =
+                AUSDRUCK,
             'Expected :, got end of input',
         ];
         yield 'Struct: missing colon between field name and type' => [
@@ -91,6 +102,46 @@ final class TypeParserTest extends TestCase
         yield 'Struct: no comma between fields' => [
             '{name: string age: int}',
             'Expected }, got age',
+        ];
+        // An argument list ends at the first missing comma, so whatever follows gets blamed as the closing bracket it
+        // isn't. Forgetting the bracket is the likelier mistake, and this names it. What the token is doesn't matter:
+        // a type, a literal or an operator all end the list the same way, so a type argument list separates its
+        // elements with commas exactly like every other list in the language.
+        yield 'Type instead of a second type argument' => [
+            'list<int string>',
+            'Expected >, got string',
+        ];
+        yield 'Literal instead of a second type argument' => [
+            'list<int 42>',
+            'Expected >, got 42',
+        ];
+        yield 'Type instead of a second function parameter' => [
+            'fn(int string) -> bool',
+            'Expected ), got string',
+        ];
+        yield 'Literal instead of a second function parameter' => [
+            'fn(int 42) -> string',
+            'Expected ), got 42',
+        ];
+        yield 'Unclosed function parameter list' => [
+            'fn(int -> string',
+            'Expected ), got ->',
+        ];
+        yield 'Unclosed type argument list' => [
+            'list<int .',
+            'Expected >, got .',
+        ];
+        // A `<` after a name that isn't a generic constructor might be a less-than, so the argument list after it is
+        // only tried, and any error inside it merely rules that reading out. A broken list nested in one is nested in
+        // the trying too, which is why the outer `<` is blamed rather than the comma the inner list is missing—the
+        // reading fallen back to is a less-than, and it is that one the tokens after it then have to fit.
+        yield 'Committed type argument list broken inside a speculative one' => [
+            'MyType<list<int int>>',
+            'Unexpected <',
+        ];
+        yield 'Committed type argument list broken on its own' => [
+            'list<list<int int>>',
+            'Expected >, got int',
         ];
         // A type string is a whole type, so anything after the first complete one is an error rather than ignored.
         yield 'Trailing identifier' => [
@@ -212,8 +263,13 @@ final class TypeParserTest extends TestCase
     {
         yield 'Name is not an identifier' => ['42: int', 'Expected type name, got 42'];
         yield 'Missing colon after name' => ['Foo int', 'Expected :, got int'];
-        yield 'End of input after colon' => ['Foo:', 'Expected a type for Foo, got end of input'];
-        yield 'Non-type token after colon' => ['Foo: ->', 'Expected a type for Foo, got ->'];
+        // A declaration string holds several declarations, so the one that is broken says which it is.
+        yield 'End of input after colon' => ['Foo:', 'Expected type for Foo, got end of input'];
+        yield 'Non-type token after colon' => ['Foo: ->', 'Expected type for Foo, got ->'];
+        yield 'Second declaration is the broken one' => [
+            'Foo: int Bar: ->',
+            'Expected type for Bar, got ->',
+        ];
     }
 
     #[DataProvider('syntaxErrorCases')]

--- a/tests/unit/Parser/TypeParserTest.php
+++ b/tests/unit/Parser/TypeParserTest.php
@@ -143,6 +143,23 @@ final class TypeParserTest extends TestCase
             'list<list<int int>>',
             'Expected >, got int',
         ];
+        // A token is underlined as wide as it is written, not as wide as it prints back: `1.50` occupies four
+        // columns even though the literal re-prints as `1.5`. The extent is recorded by the tokenizer while it reads
+        // the source, because the token itself no longer remembers how it was spelled.
+        yield 'Number literal wider than it prints' => [
+            <<<'AUSDRUCK'
+                list<1.50>
+                     ====
+                AUSDRUCK,
+            'Expected type, got 1.5',
+        ];
+        yield 'Number literal with leading zeros' => [
+            <<<'AUSDRUCK'
+                list<007>
+                     ===
+                AUSDRUCK,
+            'Expected type, got 7',
+        ];
         // A type string is a whole type, so anything after the first complete one is an error rather than ignored.
         yield 'Trailing identifier' => [
             'int foo',


### PR DESCRIPTION
A `ParsedToken` used to carry a line and column and reconstruct its extent by measuring how the token prints back. A literal that does not round-trip prints narrower than it was written — `007` as `7`, `1.50` as `1.5` — so its span, and the end of the input just past it, landed short of where the source actually reached.

This records the extent while the source is being read instead. A new `Source` owns the characters and the one rule for moving past them, so a scanner never tracks a line or column of its own, and a string literal crossing a line is handled by construction rather than by a branch that repeats the rule. Each token is given the span `Source` measured; `ParsedToken` just holds it.

### Behavior changes
- Token spans/locations are as-**written**, not as-**printed** (`1.50`, `007`, and the end of input after them).
- A multi-line string literal no longer offsets the line number of every token after it.

Split from #70.

**Blocked by #71.** This slice removes `->line`/`->column` from `ParsedToken`, which #71's refactor first stops reading directly. Rebase onto 0.2.x and mark ready once #71 merges.