### PR TITLE
Let a constructor's arity decide whether a `<` commits

### DIFF
--- a/src/Parser/TypeConstructor.php
+++ b/src/Parser/TypeConstructor.php
@@ -10,9 +10,10 @@ use Eventjet\Ausdruck\Type;
  * Every type the language spells itself, as opposed to the ones a consumer adds as aliases. This is the only list of
  * them, and how many type arguments each one takes is stated once, in {@see self::typeArgumentCount()}. Both of the
  * questions the parser asks about a constructor are answers to that one number: {@see Types::resolve()} checks the
- * count it was given against it, and {@see self::takesTypeArguments()} asks whether it is greater than zero. Deriving
- * them means a constructor can't be given an arity in one place and checked against a different one in another—the
- * exhaustive match forces a new case to be given a count, and there is no second count for it to disagree with.
+ * count it was given against it, and {@see TypeParser::parse()} asks whether it is greater than zero before committing
+ * a `<` to being a type argument list. Deriving them means a constructor can't be given an arity in one place and
+ * checked against a different one in another—the exhaustive match forces a new case to be given a count, and there is
+ * no second count for it to disagree with.
  *
  * The case names are the names as written, which is why some of them are PHP keywords.
  *
@@ -53,15 +54,5 @@ enum TypeConstructor: string
             self::String, self::Int, self::Float, self::Bool, self::Any, self::None => 0,
             self::Fn, self::Struct => null,
         };
-    }
-
-    /**
-     * Whether a `<` directly after this name opens a type argument list. It does for the constructors that take at
-     * least one, and for nothing else, which is what lets `a:int < b:int` read as a comparison: see
-     * {@see TypeParser::parse()}, which has to decide what the `<` is before there is a resolved type to ask.
-     */
-    public function takesTypeArguments(): bool
-    {
-        return ($this->typeArgumentCount() ?? 0) > 0;
     }
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -104,7 +104,11 @@ final class TypeParser
         if ($tokens->peek()?->token !== Token::OpenAngle) {
             return new TypeNode($name, [], $parsedToken->location());
         }
-        if (TypeConstructor::tryFrom($name)?->takesTypeArguments() ?? false) {
+        // Only a name with a declared arity of its own can commit to reading a type argument list. A name that isn't a
+        // built-in constructor has none, and neither has one that is never written `name<...>` in the first place —
+        // `fn`, which took its own route above, and a struct, which is written as its fields.
+        $arity = TypeConstructor::tryFrom($name)?->typeArgumentCount();
+        if ($arity !== null && $arity > 0) {
             // A generic constructor is committed: the `<` can only be its argument list, so whatever goes wrong in
             // there is a genuine error, reported where it happens rather than rewound.
             $tokens->next();


### PR DESCRIPTION
Slice 1 of 4 splitting #63.

Folds a type constructor's arity into a single source. `TypeConstructor` stated it twice — as `typeArgumentCount()` and again as `takesTypeArguments()`, which the parser used to tell `list<int>` from a comparison. `TypeParser::parse()` now reads the count directly, so there's one number and nothing for a second to drift from.

No behavior change; covered by the existing type-parser tests. Independent of the other slices.

Split from #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
