### PR TITLE
Fold binary operators onto a shared base, scanned from one table

### DIFF
--- a/src/And_.php
+++ b/src/And_.php
@@ -4,28 +4,19 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
-
-use function sprintf;
 
 /**
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class And_ extends Expression
+final class And_ extends BinaryOperator
 {
-    public function __construct(public readonly Expression $left, public readonly Expression $right)
+    #[Override]
+    public function token(): Token
     {
-    }
-
-    public function __toString(): string
-    {
-        return sprintf(
-            '%s && %s',
-            Precedence::parenthesize($this->left, Precedence::And),
-            Precedence::parenthesize($this->right, Precedence::Comparison),
-        );
+        return Token::And;
     }
 
     /**
@@ -38,22 +29,8 @@ final class And_ extends Expression
     }
 
     #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->left->equals($other->left)
-            && $this->right->equals($other->right);
-    }
-
-    #[Override]
     public function getType(): Type
     {
         return Type::bool();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->left->location()->to($this->right->location());
     }
 }

--- a/src/BinaryOperator.php
+++ b/src/BinaryOperator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+/**
+ * An operator with two operand sub-expressions and an infix spelling. Two such operators differ only in the token they
+ * are spelled with, how they evaluate, and the type they give the result — everything else lives here, and printing
+ * most of all: {@see Precedence::binary()} derives the operand slots from the node's level, and the level is looked up
+ * from that same token, so a subclass has no way to print itself in a way the parser would read back differently.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+abstract class BinaryOperator extends Expression
+{
+    public function __construct(public readonly Expression $left, public readonly Expression $right)
+    {
+    }
+
+    final public function __toString(): string
+    {
+        return Precedence::binary($this);
+    }
+
+    /**
+     * How the operator is spelled in the language, e.g. `+`. Taken from the token the parser reads it as, so the
+     * printer can't spell an operator differently than the lexer reads it.
+     */
+    final public function symbol(): string
+    {
+        return $this->token()->value;
+    }
+
+    /**
+     * Two operator nodes are the same expression when they are the same operator over equal operands. The class is
+     * what says which operator, for every operator but the comparisons: {@see Comparison} holds four of its six in one
+     * class and so overrides this to compare that too. It is the one piece of the ritual a subclass may restate.
+     */
+    #[Override]
+    public function equals(Expression $other): bool
+    {
+        return $other instanceof static
+            && $this->left->equals($other->left)
+            && $this->right->equals($other->right);
+    }
+
+    #[Override]
+    final public function location(): Span
+    {
+        return $this->left->location()->to($this->right->location());
+    }
+
+    /**
+     * The token the parser reads this operator as. Answering it is what gives the operator both its spelling and its
+     * precedence level, so a new operator can't be declared without placing it in the cascade.
+     */
+    abstract public function token(): Token;
+}

--- a/src/Comparison.php
+++ b/src/Comparison.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
-
-use function sprintf;
 
 /**
  * A comparison of two operands by one of the six comparison operators. Everything a comparison does—printing,
  * evaluating, type-checking, comparing itself to another expression—is the same whichever operator it holds, and lives
- * here; the operator only supplies the symbol and the rule that decides it, both carried by {@see ComparisonOperator}.
+ * here or in {@see BinaryOperator}; the operator only supplies the symbol and the rule that decides it, both carried by
+ * {@see ComparisonOperator}.
  *
  * Four of the six operators are plain instances of this class, which is why it isn't abstract. `===` and `>` are the
  * exceptions: each keeps a final subclass of its own ({@see Eq}, {@see Gt}), only because {@see Expression::eq()} and
@@ -22,23 +21,20 @@ use function sprintf;
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-class Comparison extends Expression
+class Comparison extends BinaryOperator
 {
     public function __construct(
         private readonly ComparisonOperator $operator,
-        public readonly Expression $left,
-        public readonly Expression $right,
+        Expression $left,
+        Expression $right,
     ) {
+        parent::__construct($left, $right);
     }
 
-    public function __toString(): string
+    #[Override]
+    final public function token(): Token
     {
-        return sprintf(
-            '%s %s %s',
-            Precedence::parenthesize($this->left, Precedence::Additive),
-            $this->operator->value,
-            Precedence::parenthesize($this->right, Precedence::Additive),
-        );
+        return $this->operator->token();
     }
 
     #[Override]
@@ -47,6 +43,13 @@ class Comparison extends Expression
         return $this->operator->compare($this->left->evaluate($scope), $this->right->evaluate($scope));
     }
 
+    /**
+     * Which operator is held is part of a comparison's identity, and it is the one piece of that identity
+     * {@see BinaryOperator::equals()} can't see: the four operators without a subclass are all the same class, so
+     * `a < b` and `a >= b` would otherwise compare equal. Matching on {@see self} rather than `static` is what lets
+     * {@see Eq} equal a plain Comparison holding {@see ComparisonOperator::Equals}—they are the same expression, and
+     * the subclass exists only to keep a return type from widening.
+     */
     #[Override]
     public function equals(Expression $other): bool
     {
@@ -60,11 +63,5 @@ class Comparison extends Expression
     public function getType(): Type
     {
         return Type::bool();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->left->location()->to($this->right->location());
     }
 }

--- a/src/ComparisonOperator.php
+++ b/src/ComparisonOperator.php
@@ -4,25 +4,48 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
+use Eventjet\Ausdruck\Parser\Token;
+
 /**
- * The six comparison operators, each paired with the rule that decides it: `===` and `!==` compare any two values of
- * the same type by deep structural equality ({@see ValueEquality}), `>`, `<`, `>=` and `<=` compare two numbers. This
- * only says how a pair of operands that already type-checks is decided; which operands an operator will accept is
- * {@see Expr::checkComparison()}'s business. Keeping that there rather than here is what holds the dependencies one
- * way: this enum needs to know about runtime values and nothing else, while deciding what an operator accepts means
- * knowing about {@see Expression}, {@see Type} and the errors raised for a mismatch.
+ * The six comparison operators, each paired with the token that spells it and the rule that decides it: `===` and `!==`
+ * compare any two values of the same type by deep structural equality ({@see ValueEquality}), `>`, `<`, `>=` and `<=`
+ * compare two numbers. This only says how an operator is written and how a pair of operands that already type-checks is
+ * decided; which operands an operator will accept is {@see Expr::checkComparison()}'s business. Keeping that there
+ * rather than here is what holds the dependencies one way: deciding what an operator accepts means knowing about
+ * {@see Expression}, {@see Type} and the errors raised for a mismatch, none of which this needs.
+ *
+ * The enum is deliberately not backed. An operator's spelling is its {@see self::token()}'s, so `===` is written in one
+ * place, and a backing value would be a second spelling for that one to drift from.
  *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-enum ComparisonOperator: string
+enum ComparisonOperator
 {
-    case Equals = '===';
-    case NotEquals = '!==';
-    case GreaterThan = '>';
-    case LessThan = '<';
-    case GreaterThanOrEqual = '>=';
-    case LessThanOrEqual = '<=';
+    case Equals;
+    case NotEquals;
+    case GreaterThan;
+    case LessThan;
+    case GreaterThanOrEqual;
+    case LessThanOrEqual;
+
+    /**
+     * The token this operator is spelled with, and so — by way of {@see BinaryOperator::symbol()} — the spelling it
+     * prints as and the level it binds at. The two angle tokens are named for their other job, delimiting a type
+     * parameter list like `list<int>`; the lexer emits the same token for both, so these are the `<` and `>` the
+     * parser reads as comparisons.
+     */
+    public function token(): Token
+    {
+        return match ($this) {
+            self::Equals => Token::TripleEquals,
+            self::NotEquals => Token::NotEquals,
+            self::GreaterThan => Token::CloseAngle,
+            self::LessThan => Token::OpenAngle,
+            self::GreaterThanOrEqual => Token::GreaterThanEquals,
+            self::LessThanOrEqual => Token::LessThanEquals,
+        };
+    }
 
     public function compare(mixed $left, mixed $right): bool
     {

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -224,7 +224,7 @@ final class Expr
     {
         match ($operator) {
             ComparisonOperator::Equals,
-            ComparisonOperator::NotEquals => self::assertSameType($left, $right, $operator->value),
+            ComparisonOperator::NotEquals => self::assertSameType($left, $right, $operator->token()->value),
             ComparisonOperator::GreaterThan,
             ComparisonOperator::LessThan,
             ComparisonOperator::GreaterThanOrEqual,

--- a/src/Lambda.php
+++ b/src/Lambda.php
@@ -27,6 +27,11 @@ final class Lambda extends Expression
         $this->location = $location;
     }
 
+    /**
+     * A lambda with no parameters prints as `|| body`, and the lexer reads `||` back as the or operator rather than an
+     * empty parameter list, so that one shape doesn't round-trip. The parser can't produce such a lambda for the same
+     * reason it can't read one; only {@see Expr::lambda()} can, by being passed no parameter names.
+     */
     public function __toString(): string
     {
         return sprintf('|%s| %s', implode(', ', $this->parameters), $this->body);

--- a/src/Or_.php
+++ b/src/Or_.php
@@ -4,28 +4,19 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
-
-use function sprintf;
 
 /**
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class Or_ extends Expression
+final class Or_ extends BinaryOperator
 {
-    public function __construct(public readonly Expression $left, public readonly Expression $right)
+    #[Override]
+    public function token(): Token
     {
-    }
-
-    public function __toString(): string
-    {
-        return sprintf(
-            '%s || %s',
-            Precedence::parenthesize($this->left, Precedence::Or),
-            Precedence::parenthesize($this->right, Precedence::And),
-        );
+        return Token::Or;
     }
 
     /**
@@ -38,22 +29,8 @@ final class Or_ extends Expression
     }
 
     #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->left->equals($other->left)
-            && $this->right->equals($other->right);
-    }
-
-    #[Override]
     public function getType(): Type
     {
         return Type::bool();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->left->location()->to($this->right->location());
     }
 }

--- a/src/Parser/Peekable.php
+++ b/src/Parser/Peekable.php
@@ -83,6 +83,12 @@ final class Peekable
                     $this->items->next();
                 }
                 if (!$this->items->valid()) {
+                    /**
+                     * @infection-ignore-all Removing this return is an equivalent mutant, not an untested branch.
+                     * A finished generator answers null from current(), so the loop would buffer that null, run
+                     * until the buffer reached $target, and hand back the same null this returns — only after
+                     * padding the buffer with as many of them as the caller looked ahead.
+                     */
                     return null;
                 }
                 $this->buffer[] = $this->items->current();

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -27,6 +27,19 @@ final class Tokenizer
     private const UNDERSCORE = 95;
 
     /**
+     * Every character that begins an operator is listed once, in the match below, and its arm answers which operator it
+     * begins: the token itself for a character that is a whole operator on its own, {@see self::pair()} for one that
+     * may be completed by a second, {@see self::angle()} for the two that may be and mean something else when they
+     * aren't, and {@see self::exact()} for one that begins a token and nothing else. Giving `+` a longer reading later
+     * means changing what its arm answers, not moving the arm somewhere a different rule applies.
+     *
+     * The arms only look ahead; naming the token is all they do. Scanning past it is the loop's job below, and it needs
+     * nothing but the answer: every {@see Token}'s value is the source text that spells it, so the operator is as many
+     * characters long as its own name, wherever the arm that named it looked.
+     *
+     * Everything below that starts with a character no operator can: whitespace, a quote, a digit, or the start of an
+     * identifier. Those are told apart by asking, because they are classes of character rather than single ones.
+     *
      * @param iterable<mixed, string> $chars
      * @return iterable<ParsedToken>
      */
@@ -42,7 +55,8 @@ final class Tokenizer
             if ($char === null) {
                 break;
             }
-            $singleCharToken = match ($char) {
+            $startCol = $column;
+            $operator = match ($char) {
                 '.' => Token::Dot,
                 '(' => Token::OpenParen,
                 ')' => Token::CloseParen,
@@ -52,12 +66,27 @@ final class Tokenizer
                 ']' => Token::CloseBracket,
                 '{' => Token::OpenBrace,
                 '}' => Token::CloseBrace,
+                '=' => self::exact($chars, $line, $column, Token::TripleEquals),
+                '!' => self::exact($chars, $line, $column, Token::NotEquals),
+                '&' => self::exact($chars, $line, $column, Token::And),
+                '<' => self::angle($chars, Token::OpenAngle, Token::LessThanEquals),
+                '>' => self::angle($chars, Token::CloseAngle, Token::GreaterThanEquals),
+                // A `-` always yields Token::Minus, never a sign folded into the number literal that follows it:
+                // {@see \Eventjet\Ausdruck\Expr::negative()} does that folding once the minus is known to be a
+                // negation. Doing it here would let whitespace silently decide what `a -2` means.
+                '-' => self::pair($chars, '>', Token::Minus, Token::Arrow),
+                '|' => self::pair($chars, '|', Token::Pipe, Token::Or),
                 default => null,
             };
-            if ($singleCharToken !== null) {
-                $chars->next();
-                yield new ParsedToken($singleCharToken, $line, $column);
-                $column++;
+            if ($operator !== null) {
+                // Walking off what the arm named. The assert is the rule above, checked where it is relied on: a
+                // token whose value is not the text that spells it would leave the cursor past input it never read.
+                foreach (str_split($operator->value) as $expected) {
+                    assert($chars->peek() === $expected);
+                    $chars->next();
+                    $column++;
+                }
+                yield new ParsedToken($operator, $line, $startCol);
                 continue;
             }
             if (ctype_space($char)) {
@@ -71,32 +100,9 @@ final class Tokenizer
                 continue;
             }
             if ($char === '"') {
-                $startLine = $line;
-                $startCol = $column;
                 $chars->next();
                 $column++;
-                yield new ParsedToken(self::string($chars, $line, $column), $startLine, $startCol);
-                continue;
-            }
-            $startCol = $column;
-            $multiCharToken = match ($char) {
-                '=' => self::exact($chars, $line, $column, '===', Token::TripleEquals),
-                '!' => self::exact($chars, $line, $column, '!==', Token::NotEquals),
-                '&' => self::exact($chars, $line, $column, '&&', Token::And),
-                '<' => self::angle($chars, $column, Token::OpenAngle, Token::LessThanEquals),
-                '>' => self::angle($chars, $column, Token::CloseAngle, Token::GreaterThanEquals),
-                /**
-                 * The sign is never folded into a number literal: a `-` always yields Token::Minus, and
-                 * {@see \Eventjet\Ausdruck\Expr::negative()} turns a negated number literal back into a negative one.
-                 * If the sign were folded in here, whitespace would silently decide the meaning of `a -2`:
-                 * subtraction, or `a` followed by the literal -2.
-                 */
-                '-' => self::bareOrPair($chars, $column, '>', Token::Minus, Token::Arrow),
-                '|' => self::bareOrPair($chars, $column, '|', Token::Pipe, Token::Or),
-                default => null,
-            };
-            if ($multiCharToken !== null) {
-                yield new ParsedToken($multiCharToken, $line, $startCol);
+                yield new ParsedToken(self::string($chars, $line, $column), $line, $startCol);
                 continue;
             }
             if (is_numeric($char)) {
@@ -142,32 +148,30 @@ final class Tokenizer
     }
 
     /**
-     * Scans an operator that is the only token starting with its first character: `===`, `!==`, and `&&`. Once that
+     * Answers the operator that is the only token starting with its first character: `===`, `!==`, and `&&`. Once that
      * first character is there, the whole sequence is required; anything short of it is an error naming the operator
-     * that was expected and underlining the characters that were actually read.
+     * that was expected and underlining the characters that were actually read. The sequence is the token's own
+     * spelling, so the operator the error names is the one it was scanning for, and $ahead—how far into that spelling
+     * the reading got—is at once how far to peek, how much was read, and where the underline ends.
      *
      * @param Peekable<string> $chars
      * @param positive-int $line
-     * @param positive-int $column
-     * @param non-empty-string $sequence
+     * @param positive-int $column Where the first character is. Nothing here moves the cursor; the caller does that.
      */
-    private static function exact(Peekable $chars, int $line, int &$column, string $sequence, Token $token): Token
+    private static function exact(Peekable $chars, int $line, int $column, Token $token): Token
     {
-        $startColumn = $column;
         $read = '';
-        foreach (str_split($sequence) as $char) {
-            if ($chars->peek() !== $char) {
-                $endColumn = $column - 1;
-                // The main loop only dispatches here after peeking $sequence's first character, so that one matched.
+        foreach (str_split($token->value) as $ahead => $char) {
+            if ($chars->peek($ahead) !== $char) {
+                $endColumn = $column + $ahead - 1;
+                // The main loop only dispatches here after peeking the token's first character, so that one matched.
                 assert($endColumn >= 1);
                 throw SyntaxError::create(
-                    sprintf('Expected %s, got %s', $sequence, $read),
-                    new Span($line, $startColumn, $line, $endColumn),
+                    sprintf('Expected %s, got %s', $token->value, $read),
+                    new Span($line, $column, $line, $endColumn),
                 );
             }
             $read .= $char;
-            $chars->next();
-            $column++;
         }
         return $token;
     }
@@ -175,45 +179,31 @@ final class Tokenizer
     /**
      * `<` and `>` each stand for two things: on their own they are the angle brackets of a generic type (which the
      * expression parser also reads as less-than and greater-than), and followed by `=` they are the comparison
-     * operators `<=` and `>=`. The pair reading wins with one exception: two `=` after the angle mean a `===` follows,
-     * as in `foo:list<int>===bar`, so the angle stays bare instead of stealing the first `=` and leaving behind a `==`
-     * that is no token at all.
+     * operators `<=` and `>=`. That is {@see self::pair()}'s rule, with one exception: two `=` after the angle mean a
+     * `===` follows, as in `foo:list<int>===bar`, so the angle stays bare instead of stealing the first `=` and leaving
+     * behind a `==` that is no token at all.
      *
      * @param Peekable<string> $chars
-     * @param positive-int $column
      */
-    private static function angle(Peekable $chars, int &$column, Token $bare, Token $pair): Token
+    private static function angle(Peekable $chars, Token $bare, Token $pair): Token
     {
-        $chars->next();
-        $column++;
-        if ($chars->peek() !== '=' || $chars->peek(1) === '=') {
-            return $bare;
-        }
-        $chars->next();
-        $column++;
-        return $pair;
+        return $chars->peek(1) === '=' && $chars->peek(2) === '='
+            ? $bare
+            : self::pair($chars, '=', $bare, $pair);
     }
 
     /**
      * A character that means one token on its own and another when $second completes it: `-` and `->`, `|` and `||`.
-     * The pair always wins. For `->` it's the only reading that can be meant: no expression continues with a bare `-`
-     * followed by a `>`. For `||` it's a choice: the two bars could also be the empty parameter list of a lambda, so
-     * that list is written `| |`, and glued bars are the or they almost always are.
+     * The pair wins where it can. For `->` it's the only reading that can be meant: no expression continues with a bare
+     * `-` followed by a `>`. For `||` it's a choice: the two bars could also be the empty parameter list of a lambda,
+     * so that list is written `| |`, and glued bars are the or they almost always are.
      *
      * @param Peekable<string> $chars
-     * @param positive-int $column
      * @param non-empty-string $second The character that, if it comes next, makes this $pair instead of $bare.
      */
-    private static function bareOrPair(Peekable $chars, int &$column, string $second, Token $bare, Token $pair): Token
+    private static function pair(Peekable $chars, string $second, Token $bare, Token $pair): Token
     {
-        $chars->next();
-        $column++;
-        if ($chars->peek() !== $second) {
-            return $bare;
-        }
-        $chars->next();
-        $column++;
-        return $pair;
+        return $chars->peek(1) === $second ? $pair : $bare;
     }
 
     /**

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck;
 
 use Eventjet\Ausdruck\Parser\ExpressionParser;
+use Eventjet\Ausdruck\Parser\Token;
+use LogicException;
 
 use function sprintf;
 
@@ -13,16 +15,19 @@ use function sprintf;
  * an operator's level in that cascade, the higher its case's value here. The two have to agree, because this exists only
  * to undo what the cascade does when an expression is printed back out.
  *
- * An operator prints each operand with {@see self::parenthesize()}, passing the level the parser reads that operand at:
+ * An operand is printed with {@see self::parenthesize()}, passing the level the parser reads that operand at. A binary
+ * operator picks nothing by hand: {@see self::binary()} looks the node's level up in {@see self::of()} and derives both
+ * operand slots from it, so how a node prints can't disagree with how it re-parses.
  * {@see ExpressionParser::parseOr()} reads the right side of `||` by calling {@see ExpressionParser::parseAnd()}, so
- * `||` prints its right side at {@see self::And}. An operand looser than the level it sits at is wrapped in
- * parentheses, because printing it bare would let the surrounding operator capture one of its parts, and parsing the
- * result back would then give a different tree. An operand at least as tight needs no parentheses, so redundant ones —
- * the parentheses in `(a:int - b:int) - c:int`, which the left-associative `-` would have grouped that way anyway —
- * are dropped.
+ * `||` prints its right side at {@see self::And}, one level tighter than its own. An operand looser than the level it
+ * sits at is wrapped in parentheses, because printing it bare would let the surrounding operator capture one of its
+ * parts, and parsing the result back would then give a different tree. An operand at least as tight needs no
+ * parentheses, so redundant ones — the parentheses in `(a:int - b:int) - c:int`, which the left-associative `-` would
+ * have grouped that way anyway — are dropped.
  *
- * The levels are not stored on the nodes: grouping leaves no trace in the tree, so the same tree always prints the same
- * way regardless of whether it was built with parentheses, in the builder API, or by the parser.
+ * A binary operator's level comes from the token it is spelled with, so an operator can't exist without one. Grouping,
+ * on the other hand, is not stored anywhere: parentheses leave no trace in the tree, so the same tree always prints the
+ * same way regardless of whether it was built with them, in the builder API, or by the parser.
  *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
@@ -57,6 +62,25 @@ enum Precedence: int
     }
 
     /**
+     * Prints a binary operator node. Its level comes from {@see self::of()}, and both operand slots follow from the
+     * level alone: the right slot is one level tighter, because every level of the cascade reads its right operand by
+     * calling the next one down, and the left slot is the level's {@see self::leftSlot()}. `a:int - (b:int - c:int)`
+     * keeps its parentheses because the right slot is the tighter one; `(a:int - b:int) - c:int` loses them because
+     * the additive left slot isn't; `(a:int === b:int) === c:bool` keeps them on either side because the comparison
+     * level's left slot is tighter too.
+     */
+    public static function binary(BinaryOperator $operator): string
+    {
+        $level = self::of($operator);
+        return sprintf(
+            '%s %s %s',
+            self::parenthesize($operator->left, $level->leftSlot()),
+            $operator->symbol(),
+            self::parenthesize($operator->right, $level->tighter()),
+        );
+    }
+
+    /**
      * Prints $target as it appears before a postfix `.`—the receiver of a call or field access. This is the
      * {@see self::Primary} slot, so precedence alone would never wrap anything; a bare number literal is the one
      * exception, and needs parentheses for a reason the precedence cascade doesn't model. `2.abs:int()` re-tokenizes
@@ -76,26 +100,65 @@ enum Precedence: int
      * Only the nodes that bind loosely enough to ever need wrapping are named; everything else is primary-tight. The
      * default is deliberately forgiving rather than a hard error: {@see Expression} is public API, so a consumer can
      * add nodes this enum has never heard of, and an unknown node is almost always atomic—the safe reading is to
-     * treat it as {@see self::Primary} rather than reject it. A node whose text runs past its own operands, though —
-     * any operator, and every lambda — has to be listed here, or printing it as an operand would drop the parentheses
-     * it needs. (A number literal is the one primary-tight node that still needs wrapping in a slot; that's a lexical
-     * quirk of the postfix `.`, handled in {@see self::parenthesizeTarget()} rather than by a level of its own.)
+     * treat it as {@see self::Primary} rather than reject it. It is never reached by an operator of this library's
+     * own, though: a {@see BinaryOperator} carries the token it is spelled with, which fixes its level in
+     * {@see self::ofToken()}, so one can't be added without being placed in the cascade. (A number literal is the one
+     * primary-tight node that still needs wrapping in a slot; that's a lexical quirk of the postfix `.`, handled in
+     * {@see self::parenthesizeTarget()} rather than by a level of its own.)
      */
     private static function of(Expression $expr): self
     {
         return match (true) {
+            $expr instanceof BinaryOperator => self::ofToken($expr->token()),
             $expr instanceof Lambda => self::Lambda,
-            $expr instanceof Or_ => self::Or,
-            $expr instanceof And_ => self::And,
-            $expr instanceof Comparison => self::Comparison,
-            $expr instanceof Subtract => self::Additive,
             $expr instanceof Negative => self::Unary,
+            // Subtract joins BinaryOperator when the arithmetic operators land; until then it names its own level.
+            $expr instanceof Subtract => self::Additive,
             default => self::Primary,
+        };
+    }
+
+    /**
+     * The level the parser reads $token at, listing the binary levels of the cascade in the same order they appear
+     * there. A token that spells no binary operator can't reach this: the only caller passes what a
+     * {@see BinaryOperator} answered.
+     */
+    private static function ofToken(Token $token): self
+    {
+        return match ($token) {
+            Token::Or => self::Or,
+            Token::And => self::And,
+            Token::TripleEquals, Token::NotEquals, Token::CloseAngle, Token::OpenAngle,
+            Token::GreaterThanEquals, Token::LessThanEquals => self::Comparison,
+            default => throw new LogicException(sprintf('%s is not a binary operator', $token->value)),
         };
     }
 
     private function bindsLooserThan(self $slot): bool
     {
         return $this->value < $slot->value;
+    }
+
+    /**
+     * The next tighter level: the one the parser cascade delegates to for an operand. Only the binary operator levels
+     * ask for this—{@see self::ofToken()} returns nothing else—and each of them has a tighter neighbor, so the lookup
+     * can't fail.
+     */
+    private function tighter(): self
+    {
+        return self::from($this->value + 1);
+    }
+
+    /**
+     * The slot the parser reads a binary operator's left operand at. A while-loop level folds operands into its left
+     * side at its own level — that's what makes those levels left-associative — so the left slot is the level itself.
+     * The comparison level has an if-shape instead: it reads both sides one level tighter, which is what makes the six
+     * comparison operators non-associative, and why its left slot is the tighter one. Associativity is a fact about
+     * the level, not about the operator: operators sharing a level are parsed by the same loop or if, so they can't
+     * differ in it.
+     */
+    private function leftSlot(): self
+    {
+        return $this === self::Comparison ? $this->tighter() : $this;
     }
 }


### PR DESCRIPTION
Slice 2 of 4 splitting #63.

A pure structural refactor, no behavior change: the same expressions parse, evaluate and print as before.

- New `BinaryOperator` base folds the shared shape (two operands, infix printing, structural equality, span) out of `And`, `Or` and `Comparison`.
- A binary operator answers only the token it's spelled with; `Precedence` derives its level and both operand slots from that token, so a node can't print in a way the parser reads back differently.
- `ComparisonOperator` drops its string backing and spells each operator once, as its token.
- The tokenizer scans every operator from a single match table.

`Precedence` keeps a one-line temporary arm for `Subtract`, which joins the base in the next slice.

Split from #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
