### PR TITLE
Fail int subtraction and negation that leave the int range

### DIFF
--- a/src/Arithmetic.php
+++ b/src/Arithmetic.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Override;
+
+/**
+ * The sum, difference and product: the arithmetic whose result is of the operands' own type, where {@see Division}'s is
+ * an option of it. The two halves pick their arithmetic the same way — from the operands' declared type, never from
+ * what they evaluate to, for the reason set out there — and both narrow their operands to that type before applying it.
+ *
+ * Where they differ is what happens when the result doesn't exist in that type. PHP's int arithmetic isn't closed: a
+ * sum, difference or product past the int range evaluates to a float rather than wrapping. A division has somewhere to
+ * put that — its type is already an option, so it answers none — but these operators' type is the operand type itself,
+ * so there is no value of it left to give and the only honest answer is to fail. {@see self::applyInt()} reports it the
+ * same way {@see Division::applyInt()} does, by answering null for a result that isn't there; the difference is only in
+ * what the two do with that null.
+ *
+ * Overflow is therefore checked, not observed: each operator decides in int arithmetic whether its result would leave
+ * the range, and never computes the widened value. That is what lets an int-typed node promise an int — evaluating one
+ * gives an int or throws, and a float can't escape under a type that says int.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+abstract class Arithmetic extends BinaryOperator
+{
+    #[Override]
+    final public function evaluate(Scope $scope): int|float
+    {
+        if ($this->left->matchesType(Type::float())) {
+            $left = Operand::float($this->left->evaluate($scope));
+            $right = Operand::float($this->right->evaluate($scope));
+            return $this->applyFloat($left, $right);
+        }
+        $left = Operand::int($this->left->evaluate($scope));
+        $right = Operand::int($this->right->evaluate($scope));
+        return $this->applyInt($left, $right) ?? throw EvaluationError::outsideIntRange($this);
+    }
+
+    #[Override]
+    final public function getType(): Type
+    {
+        return $this->left->getType();
+    }
+
+    /**
+     * The int result, or null if it doesn't exist in int. Decided without computing the widened value: the operands
+     * are compared against the bound the result would have to pass, in int arithmetic that can't overflow itself.
+     */
+    abstract protected function applyInt(int $left, int $right): int|null;
+
+    abstract protected function applyFloat(float $left, float $right): float;
+}

--- a/src/EvaluationError.php
+++ b/src/EvaluationError.php
@@ -6,6 +6,20 @@ namespace Eventjet\Ausdruck;
 
 use RuntimeException;
 
+use function sprintf;
+
 final class EvaluationError extends RuntimeException
 {
+    /**
+     * An int-typed expression whose result doesn't exist in int. Both operators that can raise it — {@see Arithmetic}
+     * and {@see Negative} — say so the same way, because it is the same failure: the node's type promises an int, and
+     * the honest answer is that there is no int to give rather than a float the type doesn't allow.
+     *
+     * @internal
+     * @psalm-internal Eventjet\Ausdruck
+     */
+    public static function outsideIntRange(Expression $expression): self
+    {
+        return new self(sprintf('%s leaves the int range', $expression));
+    }
 }

--- a/src/IntArithmetic.php
+++ b/src/IntArithmetic.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use const PHP_INT_MIN;
+
+/**
+ * The int arithmetic whose result may not exist in int, answered rather than computed: {@see Arithmetic} sets out why an
+ * operator decides that before widening rather than after.
+ *
+ * PHP_INT_MIN is one further from zero than PHP_INT_MAX, so negating it is the one negation with no int result. Three
+ * operators meet it, and all three are negating when they do: unary minus ({@see Negative}), multiplying by -1
+ * ({@see Multiply}) and dividing by -1 ({@see Divide}). Stating it once here is what saves the three from having to
+ * agree about it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class IntArithmetic
+{
+    /**
+     * @psalm-suppress UnusedConstructor
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * The negation of $value, or null if int has none.
+     */
+    public static function negate(int $value): int|null
+    {
+        return $value === PHP_INT_MIN ? null : -$value;
+    }
+}

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -26,10 +26,19 @@ final class Negative extends Expression
         return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::Unary));
     }
 
+    /**
+     * Negation is arithmetic too, and follows the rule {@see Arithmetic} sets: the operand is narrowed to the type it
+     * claims, and an int result that doesn't exist is reported rather than widened. Which int result that is, and why,
+     * is {@see IntArithmetic::negate()}'s to say.
+     */
     #[Override]
     public function evaluate(Scope $scope): float|int
     {
-        return -Operand::number($this->expression->evaluate($scope));
+        if ($this->expression->matchesType(Type::float())) {
+            return -Operand::float($this->expression->evaluate($scope));
+        }
+        $value = Operand::int($this->expression->evaluate($scope));
+        return IntArithmetic::negate($value) ?? throw EvaluationError::outsideIntRange($this);
     }
 
     #[Override]

--- a/src/Operand.php
+++ b/src/Operand.php
@@ -20,6 +20,11 @@ use function sprintf;
  * for an expression that was built through {@see Expr}. They exist so the nodes can go from mixed to int, float, bool or
  * object without a cast. Anything thrown here is a bug in this library, not in the expression that was evaluated.
  *
+ * {@see self::int()} used to be the exception. PHP's int arithmetic isn't closed, so an operand whose own arithmetic
+ * had overflowed arrived here as a float, honestly and for a reason no type error explained. {@see Arithmetic} now
+ * decides whether an int result exists before computing it, so the widened value is never produced and there is no
+ * longer a way for one to reach any of these.
+ *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
@@ -50,6 +55,26 @@ final class Operand
         return is_int($value) || is_float($value)
             ? $value
             : throw new EvaluationError(sprintf('Expected an int or float operand, got %s', get_debug_type($value)));
+    }
+
+    /**
+     * @infection-ignore-all Unreachable; see the class docblock.
+     */
+    public static function int(mixed $value): int
+    {
+        return is_int($value)
+            ? $value
+            : throw new EvaluationError(sprintf('Expected an int operand, got %s', get_debug_type($value)));
+    }
+
+    /**
+     * @infection-ignore-all Unreachable; see the class docblock.
+     */
+    public static function float(mixed $value): float
+    {
+        return is_float($value)
+            ? $value
+            : throw new EvaluationError(sprintf('Expected a float operand, got %s', get_debug_type($value)));
     }
 
     /**

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -112,8 +112,6 @@ enum Precedence: int
             $expr instanceof BinaryOperator => self::ofToken($expr->token()),
             $expr instanceof Lambda => self::Lambda,
             $expr instanceof Negative => self::Unary,
-            // Subtract joins BinaryOperator when the arithmetic operators land; until then it names its own level.
-            $expr instanceof Subtract => self::Additive,
             default => self::Primary,
         };
     }
@@ -130,6 +128,7 @@ enum Precedence: int
             Token::And => self::And,
             Token::TripleEquals, Token::NotEquals, Token::CloseAngle, Token::OpenAngle,
             Token::GreaterThanEquals, Token::LessThanEquals => self::Comparison,
+            Token::Minus => self::Additive,
             default => throw new LogicException(sprintf('%s is not a binary operator', $token->value)),
         };
     }

--- a/src/Subtract.php
+++ b/src/Subtract.php
@@ -4,59 +4,52 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
 
-use function sprintf;
+use function max;
+use function min;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 /**
+ * The difference of two numbers. Total in int only up to the range, in the way {@see Arithmetic} describes.
+ *
  * @internal
  * @psalm-internal Eventjet\Ausdruck
  */
-final class Subtract extends Expression
+final class Subtract extends Arithmetic
 {
-    public function __construct(public readonly Expression $minuend, public readonly Expression $subtrahend)
-    {
-    }
+    /**
+     * The subtrahend that moves the minuend nowhere. Both bounds clamp to it, and to the same one: it is the sign
+     * change, not the value, that decides which of them the subtrahend can act on.
+     */
+    private const int INERT = 0;
 
-    public function __toString(): string
+    #[Override]
+    public function token(): Token
     {
-        return sprintf(
-            '%s - %s',
-            Precedence::parenthesize($this->minuend, Precedence::Additive),
-            Precedence::parenthesize($this->subtrahend, Precedence::Unary),
-        );
+        return Token::Minus;
     }
 
     /**
-     * @psalm-suppress InvalidOperand Psalm's strict binary operands mode rejects int|float on either side, because it
-     *     can't see that {@see Expr::subtract()} has already required both operands to be of the *same* numeric type.
-     *     The int/float mix it's guarding against can't reach us.
+     * The largest and smallest minuend that still fits, given the subtrahend. Subtracting moves the minuend against
+     * the subtrahend's sign, so this is {@see Add::applyInt()} with the clamps swapped: only a negative subtrahend can
+     * carry the minuend past PHP_INT_MAX, only a positive one past PHP_INT_MIN, and clamping the other side to
+     * {@see self::INERT} is again what keeps the bound computable.
      */
     #[Override]
-    public function evaluate(Scope $scope): int|float
+    protected function applyInt(int $left, int $right): int|null
     {
-        return Operand::number($this->minuend->evaluate($scope))
-            - Operand::number($this->subtrahend->evaluate($scope));
+        $highest = PHP_INT_MAX + min($right, self::INERT);
+        $lowest = PHP_INT_MIN + max($right, self::INERT);
+        return $left > $highest || $left < $lowest ? null : $left - $right;
     }
 
     #[Override]
-    public function equals(Expression $other): bool
+    protected function applyFloat(float $left, float $right): float
     {
-        return $other instanceof self
-            && $this->minuend->equals($other->minuend)
-            && $this->subtrahend->equals($other->subtrahend);
-    }
-
-    #[Override]
-    public function getType(): Type
-    {
-        return $this->minuend->getType();
-    }
-
-    #[Override]
-    public function location(): Span
-    {
-        return $this->minuend->location()->to($this->subtrahend->location());
+        return $left - $right;
     }
 }

--- a/tests/unit/ExpressionTest.php
+++ b/tests/unit/ExpressionTest.php
@@ -22,6 +22,9 @@ use function is_string;
 use function md5;
 use function sprintf;
 
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 final class ExpressionTest extends TestCase
 {
     /**
@@ -109,6 +112,17 @@ final class ExpressionTest extends TestCase
             ['nums:list<int>.some:bool(|item| item:int === 5)', new Scope(['nums' => [4, 5, 6]]), true],
             ['"Rudolph".substr:string(1, 3)', new Scope(), 'udo'],
             ['a:int - b:int - c:int', new Scope(['a' => 10, 'b' => 3, 'c' => 4]), 3],
+            // The last differences that still fit, on both ends. Subtraction decides whether its int result exists
+            // before computing it (see Arithmetic), and these are the pairs that decision has to admit — one step
+            // further in either direction is an error, covered in evaluationErrorsCases().
+            ['a:int - b:int', new Scope(['a' => PHP_INT_MAX, 'b' => 0]), PHP_INT_MAX],
+            ['a:int - b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 0]), PHP_INT_MIN],
+            ['a:int - b:int', new Scope(['a' => -1, 'b' => PHP_INT_MIN]), PHP_INT_MAX],
+            ['a:int - b:int', new Scope(['a' => PHP_INT_MIN + 1, 'b' => 1]), PHP_INT_MIN],
+            // Negation is arithmetic too: PHP_INT_MIN is the one int it has no answer for, one step past the boundary.
+            ['-a:int', new Scope(['a' => PHP_INT_MAX]), -PHP_INT_MAX],
+            ['-a:int', new Scope(['a' => PHP_INT_MIN + 1]), PHP_INT_MAX],
+            ['-a:float', new Scope(['a' => 1.5]), -1.5],
             ['"foo" === "bar"', new Scope(), false],
             ['"foo" === "foo"', new Scope(), true],
             ['foo:any === bar:any', new Scope(['foo' => 12.34, 'bar' => 12.34]), true],
@@ -402,6 +416,25 @@ final class ExpressionTest extends TestCase
             ['foo:string'],
             new Scope(['foo' => []]),
             'Expected variable "foo" to be of type string, got array: Expected string, got list<never>',
+        ];
+        // PHP's int arithmetic isn't closed: a difference past the range evaluates to a float rather than wrapping. An
+        // int-typed expression that answered one would be handing back a value of a type it doesn't have, so the
+        // operator decides up front whether its result exists and fails when it doesn't. See Arithmetic.
+        yield 'Difference past the int range' => [
+            ['a:int - b:int'],
+            new Scope(['a' => PHP_INT_MAX, 'b' => -1]),
+            'a:int - b:int leaves the int range',
+        ];
+        yield 'Difference below the int range' => [
+            ['a:int - b:int'],
+            new Scope(['a' => PHP_INT_MIN, 'b' => 1]),
+            'a:int - b:int leaves the int range',
+        ];
+        // Negating and subtracting meet the same wall: -PHP_INT_MIN is one past PHP_INT_MAX, so it has no int result.
+        yield 'Negating PHP_INT_MIN' => [
+            ['-a:int'],
+            new Scope(['a' => PHP_INT_MIN]),
+            '-a:int leaves the int range',
         ];
     }
 


### PR DESCRIPTION
Slice 3 of 4 splitting #63.

**Blocked by #74.** Rebase onto 0.2.x and mark ready once #74 merges. (Stacked on #74, so the diff shows that slice too until then.)

Makes existing `int` subtraction and unary negation fail rather than silently widen when the result leaves the `int` range. PHP's `int` arithmetic isn't closed: `PHP_INT_MAX - -1` and `-PHP_INT_MIN` evaluate to a `float`, which an `int`-typed node has no business returning.

- New `Arithmetic` base decides whether the `int` result exists *before* computing it and throws when it doesn't.
- `IntArithmetic::negate()` states the one missing negation (`PHP_INT_MIN`) once; `Negative` reports it the same way.
- `float` subtraction and negation are unchanged.

Split from #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
