### PR TITLE
Compare evaluated values strictly, PHP type included

### DIFF
--- a/tests/unit/AssertsEvaluatedValues.php
+++ b/tests/unit/AssertsEvaluatedValues.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Test\Unit;
+
+use function array_keys;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+
+/**
+ * The shared expectation of both evaluation harnesses: an evaluated value has to be the expected one, PHP type
+ * included.
+ *
+ * assertEquals() is too weak to say that. It can't tell 0 from null, null from false, or 24 from 24.0 — and those are
+ * exactly the distinctions the evaluation cases exist to pin. `isSome` on a none answers false rather than the null
+ * inside it, and an int subtraction gives back an int rather than a float: under assertEquals either case passes
+ * whether or not the library still holds up its end.
+ *
+ * Structs are the one place identity isn't available: the library builds its own objects, so an expectation is never
+ * the same instance as the result. They are therefore compared field by field, and lists element by element, until the
+ * recursion reaches a scalar — which is compared strictly. Every scalar anywhere in the value is held to the same
+ * standard, however deeply it sits.
+ */
+trait AssertsEvaluatedValues
+{
+    private static function assertEvaluatesTo(mixed $expected, mixed $actual): void
+    {
+        if (is_array($expected) && is_array($actual)) {
+            self::assertSame(array_keys($expected), array_keys($actual), 'List keys differ');
+            /** @var mixed $item */
+            foreach ($expected as $key => $item) {
+                self::assertEvaluatesTo($item, $actual[$key]);
+            }
+            return;
+        }
+        if (is_object($expected) && is_object($actual)) {
+            $expectedFields = get_object_vars($expected);
+            $actualFields = get_object_vars($actual);
+            self::assertSame(array_keys($expectedFields), array_keys($actualFields), 'Struct fields differ');
+            /** @var mixed $value */
+            foreach ($expectedFields as $field => $value) {
+                self::assertEvaluatesTo($value, $actualFields[$field]);
+            }
+            return;
+        }
+        self::assertSame($expected, $actual);
+    }
+}

--- a/tests/unit/EndToEndTest.php
+++ b/tests/unit/EndToEndTest.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 final class EndToEndTest extends TestCase
 {
+    use AssertsEvaluatedValues;
+
     /**
      * @return iterable<string, array{E2eCase}>
      */
@@ -31,7 +33,7 @@ final class EndToEndTest extends TestCase
         /** @var mixed $actual */
         $actual = $expression->evaluate(new Scope($case->input));
 
-        self::assertEquals($case->expected, $actual);
+        self::assertEvaluatesTo($case->expected, $actual);
     }
 
     /**

--- a/tests/unit/ExpressionTest.php
+++ b/tests/unit/ExpressionTest.php
@@ -27,6 +27,8 @@ use const PHP_INT_MIN;
 
 final class ExpressionTest extends TestCase
 {
+    use AssertsEvaluatedValues;
+
     /**
      * @return iterable<string, array{
      *     string | Expression | callable(): Expression,
@@ -535,7 +537,7 @@ final class ExpressionTest extends TestCase
         };
 
         /** @psalm-suppress MixedMethodCall False positive */
-        self::assertEquals($expected, $expression->evaluate($scope));
+        self::assertEvaluatesTo($expected, $expression->evaluate($scope));
     }
 
     #[DataProvider('toStringCases')]


### PR DESCRIPTION

The two evaluation harnesses — `ExpressionTest` and the end-to-end case files — both asserted their results with `assertEquals()`, which is too weak to say what they mean. It can't tell `0` from `null`, `null` from `false`, or `24` from `24.0`, and those are exactly the distinctions the cases exist to pin: `isSome` on a none answers `false` rather than the `null` inside it, and an int subtraction gives back an `int` rather than a `float`. Under `assertEquals` either case passes whether or not the library still holds up its end.

Give both harnesses one shared expectation, `AssertsEvaluatedValues`, which compares strictly. Structs are the one place identity isn't available — the library builds its own objects, so an expectation is never the same instance as the result — so they are walked field by field, and lists element by element, until the recursion reaches a scalar. Every scalar anywhere in the value is then held to the same standard, however deeply it sits.

No case changed: the suite passes as it stood, now for the reason it claims to.

Split from #76.