### PR TITLE
Add the arithmetic operator *, on a new precedence level

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Both operands must be of the same type.
 | `!==`    | Inequality            | `foo:string !== "bar"`   |                                           |
 | `-`      | Subtraction           | `foo:int - bar:int`      | Operands must be of type `int` or `float` |
 | `+`      | Addition              | `foo:int + bar:int`      | Operands must be of type `int` or `float` |
+| `*`      | Multiplication        | `foo:int * bar:int`      | Operands must be of type `int` or `float` |
 | `>`      | Greater than          | `foo:int > bar:int`      | Operands must be of type `int` or `float` |
 | `>=`     | Greater than or equal | `foo:int >= bar:int`     | Operands must be of type `int` or `float` |
 | `<`      | Less than             | `foo:int < bar:int`      | Operands must be of type `int` or `float` |
@@ -81,16 +82,16 @@ Where's the rest? We're implementing more as we need them.
 
 #### Int overflow
 
-PHP's `int` arithmetic isn't closed: a sum or difference past the `int` range evaluates to a `float` rather than
-wrapping. An `int`-typed expression that answered one would be handing back a value of a type it doesn't have, so each
+PHP's `int` arithmetic isn't closed: a sum, difference or product past the `int` range evaluates to a `float` rather
+than wrapping. An `int`-typed expression that answered one would be handing back a value of a type it doesn't have, so each
 operator decides up front whether its result exists and fails evaluation when it doesn't:
 
 ```
 a:int + b:int
 ```
 
-with `a` at `PHP_INT_MAX` and `b` at `1` is an evaluation error, not `9.2233720368548E+18`. `-` and unary `-` work the
-same way. Evaluating an `int`-typed expression therefore gives you an `int` or nothing at all — the widened value is
+with `a` at `PHP_INT_MAX` and `b` at `1` is an evaluation error, not `9.2233720368548E+18`. `-`, `*` and unary `-` work
+the same way. Evaluating an `int`-typed expression therefore gives you an `int` or nothing at all — the widened value is
 never computed, so it can't reach a caller or quietly widen the operator above it either. `float` arithmetic has no
 such wall: it goes to `INF`, as it does in PHP.
 
@@ -102,14 +103,16 @@ Operators bind from tightest to loosest in this order:
 |-------------------------------------|-----------------|
 | `.` (field, method)                 | Left            |
 | `-` (negation)                      | Right           |
+| `*`                                 | Left            |
 | `-` (subtraction), `+`              | Left            |
 | `===`, `!==`, `>`, `>=`, `<`, `<=`  | Non-associative |
 | `&&`                                | Left            |
 | `\|\|`                              | Left            |
 
 As in most languages, `&&` binds tighter than `||`, so `a:bool && b:bool || c:bool` means
-`(a:bool && b:bool) || c:bool`. Operators that share a level are left-associative across it:
-`a:int - b:int + c:int` means `(a:int - b:int) + c:int`.
+`(a:bool && b:bool) || c:bool`; `*` binds tighter than `+` and binary `-`, so `a:int + b:int * c:int` means
+`a:int + (b:int * c:int)`. Operators that share a level are left-associative across it: `a:int - b:int + c:int` means
+`(a:int - b:int) + c:int`.
 
 The comparison operators are non-associative: `a:int > b:int > c:int` is a syntax error rather than a comparison
 against the `bool` that the first comparison produces. Chain with `&&` instead.
@@ -121,13 +124,14 @@ Wrap a sub-expression in parentheses to override the precedence:
 ```
 a:bool && (b:bool || c:bool)
 (a:int - b:int) - c:int
+(a:int + b:int) * c:int
 (a:int > b:int) === c:bool
 (a:int - b:int).abs:int()
 ```
 
 Parentheses only group; they add no node of their own. Redundant ones — a group the precedence would have produced
-anyway, like `(a:int - b:int) - c:int` — parse fine and simply disappear, so printing an expression back out adds a
-pair of parentheses exactly where one is needed to parse it back into the same expression, and nowhere else.
+anyway, like `(a:int - b:int) - c:int` — parse fine and simply disappear, so printing an expression back out puts a
+pair of parentheses exactly where the precedence would otherwise regroup the tree, and nowhere else.
 
 Anywhere an expression is expected, it can be a whole one, not only at the top level. List items, struct field values,
 function arguments, and lambda bodies are all full expressions, so operators, calls, and field access are available in

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -150,6 +150,16 @@ final class Expr
         return new Add($augend, $addend);
     }
 
+    public static function multiply(Expression $multiplicand, Expression $multiplier): Multiply
+    {
+        self::assertSameNumberType($multiplicand, $multiplier, static fn(): string => sprintf(
+            'Can\'t multiply %s by %s',
+            $multiplicand->getType(),
+            $multiplier->getType(),
+        ));
+        return new Multiply($multiplicand, $multiplier);
+    }
+
     public static function gt(Expression $left, Expression $right): Gt
     {
         self::checkComparison(ComparisonOperator::GreaterThan, $left, $right);

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -33,6 +33,11 @@ abstract class Expression implements Stringable
         return Expr::add($this, $addend);
     }
 
+    public function multiply(self $multiplier): Multiply
+    {
+        return Expr::multiply($this, $multiplier);
+    }
+
     public function gt(self $right): Gt
     {
         return Expr::gt($this, $right);

--- a/src/Multiply.php
+++ b/src/Multiply.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+use function intdiv;
+use function max;
+use function min;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
+/**
+ * The product of two numbers. Total in int only up to the range, in the way {@see Arithmetic} describes.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Multiply extends Arithmetic
+{
+    #[Override]
+    public function token(): Token
+    {
+        return Token::Asterisk;
+    }
+
+    /**
+     * The two multiplicands that land exactly on a bound, and the range they enclose. {@see intdiv()} truncates toward
+     * zero, which is toward the inside of whichever bound the product approaches, so each quotient is exactly the last
+     * multiplicand that still fits — the range neither rejects a representable product nor admits an overflowing one.
+     * A negative multiplier reverses which quotient is the upper and which the lower, so they're ordered by value
+     * rather than by which limit they came from.
+     *
+     * The two multipliers that can't be asked are handled first. Zero would make {@see intdiv()} throw, and multiplying
+     * by -1 is negating, which is where the one missing product is: see {@see IntArithmetic::negate()}.
+     */
+    #[Override]
+    protected function applyInt(int $left, int $right): int|null
+    {
+        if ($right === 0) {
+            return 0;
+        }
+        if ($right === -1) {
+            return IntArithmetic::negate($left);
+        }
+        $onMax = intdiv(PHP_INT_MAX, $right);
+        $onMin = intdiv(PHP_INT_MIN, $right);
+        return $left > max($onMax, $onMin) || $left < min($onMax, $onMin) ? null : $left * $right;
+    }
+
+    #[Override]
+    protected function applyFloat(float $left, float $right): float
+    {
+        return $left * $right;
+    }
+}

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -21,7 +21,7 @@ use function str_split;
 /**
  * Expressions are parsed as a cascade of precedence levels, from loosest to tightest binding:
  *
- *     expression → or → and → comparison → additive → unary → postfix → primary
+ *     expression → or → and → comparison → additive → multiplicative → unary → postfix → primary
  *
  * Each level consumes only its own operators and delegates to the next tighter level for its operands. Precedence and
  * associativity are therefore expressed by the call graph, and a level never needs to know which operators sit above
@@ -157,11 +157,31 @@ final class ExpressionParser
      */
     private function parseAdditive(): Expression
     {
-        $left = $this->parseUnary();
+        $left = $this->parseMultiplicative();
         while (true) {
             $build = match ($this->nextToken()) {
                 Token::Plus => $left->add(...),
                 Token::Minus => $left->subtract(...),
+                default => null,
+            };
+            if ($build === null) {
+                return $left;
+            }
+            $this->tokens->next();
+            $left = $build($this->parseMultiplicative());
+        }
+    }
+
+    /**
+     * a:int * b:int * c:int
+     * =====================
+     */
+    private function parseMultiplicative(): Expression
+    {
+        $left = $this->parseUnary();
+        while (true) {
+            $build = match ($this->nextToken()) {
+                Token::Asterisk => $left->multiply(...),
                 default => null,
             };
             if ($build === null) {

--- a/src/Parser/Token.php
+++ b/src/Parser/Token.php
@@ -31,6 +31,7 @@ enum Token: string
     case Colon = ':';
     case Minus = '-';
     case Plus = '+';
+    case Asterisk = '*';
     case Arrow = '->';
 
     /**

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -63,6 +63,7 @@ final class Tokenizer
                 ':' => Token::Colon,
                 ',' => Token::Comma,
                 '+' => Token::Plus,
+                '*' => Token::Asterisk,
                 '[' => Token::OpenBracket,
                 ']' => Token::CloseBracket,
                 '{' => Token::OpenBrace,

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -44,13 +44,14 @@ enum Precedence: int
     case And = 2;
     case Comparison = 3;
     case Additive = 4;
-    case Unary = 5;
+    case Multiplicative = 5;
+    case Unary = 6;
     /**
      * Calls, field accesses and the atomic expressions (literals, variables, lists, structs) all share the tightest
      * level: none of them can have an operand stolen, so none is ever parenthesized as an operand. Lambdas look atomic
      * but are not—see {@see self::Lambda}.
      */
-    case Primary = 6;
+    case Primary = 7;
 
     /**
      * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
@@ -129,6 +130,7 @@ enum Precedence: int
             Token::TripleEquals, Token::NotEquals, Token::CloseAngle, Token::OpenAngle,
             Token::GreaterThanEquals, Token::LessThanEquals => self::Comparison,
             Token::Plus, Token::Minus => self::Additive,
+            Token::Asterisk => self::Multiplicative,
             default => throw new LogicException(sprintf('%s is not a binary operator', $token->value)),
         };
     }

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -15,6 +15,7 @@ use Eventjet\Ausdruck\Get;
 use Eventjet\Ausdruck\Lambda;
 use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\Literal;
+use Eventjet\Ausdruck\Multiply;
 use Eventjet\Ausdruck\Negative;
 use Eventjet\Ausdruck\Or_;
 use Eventjet\Ausdruck\Parser\Span;
@@ -54,6 +55,10 @@ final class ExpressionComparisonTest extends TestCase
         yield [
             Expr::add(Expr::literal(1), Expr::literal(2)),
             Expr::add(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield [
+            Expr::multiply(Expr::literal(1), Expr::literal(2)),
+            Expr::multiply(Expr::literal(1), Expr::literal(2)),
         ];
         yield [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
@@ -227,6 +232,14 @@ final class ExpressionComparisonTest extends TestCase
         yield Add::class . ' and ' . Subtract::class => [
             Expr::add(Expr::literal(1), Expr::literal(2)),
             Expr::subtract(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield Multiply::class . ': multiplicand is different' => [
+            Expr::multiply(Expr::literal(1), Expr::literal(2)),
+            Expr::multiply(Expr::literal(2), Expr::literal(2)),
+        ];
+        yield Multiply::class . ': multiplier is different' => [
+            Expr::multiply(Expr::literal(1), Expr::literal(2)),
+            Expr::multiply(Expr::literal(1), Expr::literal(1)),
         ];
         yield Call::class . ': target is different' => [
             Expr::literal(1)->call('foo', Type::int(), []),

--- a/tests/unit/ExpressionTest.php
+++ b/tests/unit/ExpressionTest.php
@@ -16,6 +16,7 @@ use Eventjet\Ausdruck\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+use function intdiv;
 use function is_array;
 use function is_callable;
 use function is_string;
@@ -116,10 +117,12 @@ final class ExpressionTest extends TestCase
             ['a:int - b:int - c:int', new Scope(['a' => 10, 'b' => 3, 'c' => 4]), 3],
             ['a:int + b:int', new Scope(['a' => 2, 'b' => 3]), 5],
             ['a:float + b:float', new Scope(['a' => 1.5, 'b' => 2.25]), 3.75],
+            ['a:int * b:int', new Scope(['a' => 4, 'b' => 6]), 24],
+            ['a:float * b:float', new Scope(['a' => 1.5, 'b' => 2.0]), 3.0],
             // The last results that still fit, on both ends. Each operator decides whether its int result exists
             // before computing it (see Arithmetic), and these are the pairs that decision has to admit — one step
-            // further in either direction is an error, covered in evaluationErrorsCases(). An operand of 0 has to
-            // pass whatever the other operand is.
+            // further in either direction is an error, covered in evaluationErrorsCases(). An operand of 0, or of 1
+            // where it's the identity, has to pass whatever the other operand is.
             ['a:int + b:int', new Scope(['a' => PHP_INT_MAX, 'b' => 0]), PHP_INT_MAX],
             ['a:int + b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 0]), PHP_INT_MIN],
             ['a:int + b:int', new Scope(['a' => PHP_INT_MAX - 1, 'b' => 1]), PHP_INT_MAX],
@@ -128,10 +131,22 @@ final class ExpressionTest extends TestCase
             ['a:int - b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 0]), PHP_INT_MIN],
             ['a:int - b:int', new Scope(['a' => -1, 'b' => PHP_INT_MIN]), PHP_INT_MAX],
             ['a:int - b:int', new Scope(['a' => PHP_INT_MIN + 1, 'b' => 1]), PHP_INT_MIN],
+            ['a:int * b:int', new Scope(['a' => PHP_INT_MAX, 'b' => 1]), PHP_INT_MAX],
+            ['a:int * b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 1]), PHP_INT_MIN],
+            ['a:int * b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 0]), 0],
+            ['a:int * b:int', new Scope(['a' => PHP_INT_MAX, 'b' => -1]), -PHP_INT_MAX],
+            // A product landing exactly on a bound, from either side and with either sign of multiplier. PHP_INT_MIN
+            // is reachable as a product where -PHP_INT_MIN is not a value at all, so the two ends aren't symmetric.
+            ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MIN, 2), 'b' => 2]), PHP_INT_MIN],
+            ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MIN, -2), 'b' => -2]), PHP_INT_MIN],
+            ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MAX, 2), 'b' => 2]), PHP_INT_MAX - 1],
+            ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MAX, -2), 'b' => -2]), PHP_INT_MAX - 1],
             // Negation is arithmetic too: PHP_INT_MIN is the one int it has no answer for, one step past the boundary.
             ['-a:int', new Scope(['a' => PHP_INT_MAX]), -PHP_INT_MAX],
             ['-a:int', new Scope(['a' => PHP_INT_MIN + 1]), PHP_INT_MAX],
             ['-a:float', new Scope(['a' => 1.5]), -1.5],
+            ['a:int + b:int * c:int', new Scope(['a' => 2, 'b' => 3, 'c' => 4]), 14],
+            ['(a:int + b:int) * c:int', new Scope(['a' => 2, 'b' => 3, 'c' => 4]), 20],
             ['a:int - b:int + c:int', new Scope(['a' => 10, 'b' => 3, 'c' => 4]), 11],
             ['"foo" === "bar"', new Scope(), false],
             ['"foo" === "foo"', new Scope(), true],
@@ -427,8 +442,8 @@ final class ExpressionTest extends TestCase
             new Scope(['foo' => []]),
             'Expected variable "foo" to be of type string, got array: Expected string, got list<never>',
         ];
-        // PHP's int arithmetic isn't closed: a sum or difference past the range evaluates to a float rather than
-        // wrapping. An int-typed expression that answered one would be handing back a value of a type it doesn't
+        // PHP's int arithmetic isn't closed: a sum, difference or product past the range evaluates to a float rather
+        // than wrapping. An int-typed expression that answered one would be handing back a value of a type it doesn't
         // have, so every operator decides up front whether its int result exists and fails when it doesn't. The
         // widened value is never computed, and never escapes. See Arithmetic.
         yield 'Sum past the int range' => [
@@ -451,11 +466,46 @@ final class ExpressionTest extends TestCase
             new Scope(['a' => PHP_INT_MIN, 'b' => 1]),
             'a:int - b:int leaves the int range',
         ];
-        // Negating and subtracting meet the same wall: -PHP_INT_MIN is one past PHP_INT_MAX, so it has no int result.
+        yield 'Product past the int range' => [
+            ['a:int * b:int'],
+            new Scope(['a' => PHP_INT_MAX, 'b' => 2]),
+            'a:int * b:int leaves the int range',
+        ];
+        yield 'Product below the int range' => [
+            ['a:int * b:int'],
+            new Scope(['a' => PHP_INT_MIN, 'b' => 2]),
+            'a:int * b:int leaves the int range',
+        ];
+        // A negative multiplier reverses which bound the product approaches, so both ends have to be tried against
+        // one: a multiplicand at either extreme passes a different one of the two.
+        yield 'Product past the int range through a negative multiplier' => [
+            ['a:int * b:int'],
+            new Scope(['a' => PHP_INT_MIN, 'b' => -2]),
+            'a:int * b:int leaves the int range',
+        ];
+        yield 'Product below the int range through a negative multiplier' => [
+            ['a:int * b:int'],
+            new Scope(['a' => PHP_INT_MAX, 'b' => -2]),
+            'a:int * b:int leaves the int range',
+        ];
+        // Negating and multiplying by -1 are the same operation, and PHP_INT_MIN is the one int neither has an answer
+        // for: -PHP_INT_MIN is one past PHP_INT_MAX.
+        yield 'Product of PHP_INT_MIN and -1' => [
+            ['a:int * b:int'],
+            new Scope(['a' => PHP_INT_MIN, 'b' => -1]),
+            'a:int * b:int leaves the int range',
+        ];
         yield 'Negating PHP_INT_MIN' => [
             ['-a:int'],
             new Scope(['a' => PHP_INT_MIN]),
             '-a:int leaves the int range',
+        ];
+        // The operator whose result left the range is the one blamed, wherever it sits: an operand can't reach the
+        // operator above it already widened, so no one else has to report the overflow second-hand.
+        yield 'The operator that overflowed is the one blamed, not the one above it' => [
+            ['(a:int + b:int) * c:int'],
+            new Scope(['a' => PHP_INT_MAX, 'b' => 1, 'c' => 2]),
+            'a:int + b:int leaves the int range',
         ];
     }
 
@@ -527,6 +577,8 @@ final class ExpressionTest extends TestCase
         yield 'Empty list literal' => ['[]', Type::listOf(Type::any())];
         yield 'Add ints' => ['a:int + b:int', Type::int()];
         yield 'Add floats' => ['a:float + b:float', Type::float()];
+        yield 'Multiply ints' => ['a:int * b:int', Type::int()];
+        yield 'Multiply floats' => ['a:float * b:float', Type::float()];
     }
 
     /**

--- a/tests/unit/Parser/ExpressionParserErrorTest.php
+++ b/tests/unit/Parser/ExpressionParserErrorTest.php
@@ -69,7 +69,9 @@ final class ExpressionParserErrorTest extends TestCase
         ];
         yield 'missing right hand side of minus' => ['foo:int -'];
         yield 'missing right hand side of plus' => ['foo:int +'];
+        yield 'missing right hand side of star' => ['foo:int *'];
         yield 'missing left hand side of plus' => ['+ foo:int', 'Expected expression, got +'];
+        yield 'missing left hand side of star' => ['* foo:int', 'Expected expression, got *'];
         // Unlike -, + is not a unary operator.
         yield 'plus as a sign' => ['a:int + + 2', 'Expected expression, got +'];
         yield 'empty string' => ['', 'Expected expression, got end of input'];
@@ -171,6 +173,11 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'add string to string' => ['foo:string + bar:string', 'Can\'t add string to string'];
         yield 'add string to int' => ['foo:int + bar:string', 'Can\'t add string to int'];
         yield 'add int to string' => ['foo:string + bar:int', 'Can\'t add int to string'];
+        yield 'multiply int by float' => ['foo:int * bar:float', 'Can\'t multiply int by float'];
+        yield 'multiply float by int' => ['foo:float * bar:int', 'Can\'t multiply float by int'];
+        yield 'multiply string by string' => ['foo:string * bar:string', 'Can\'t multiply string by string'];
+        yield 'multiply string by int' => ['foo:string * bar:int', 'Can\'t multiply string by int'];
+        yield 'multiply int by string' => ['foo:int * bar:string', 'Can\'t multiply int by string'];
         yield 'int > float' => ['foo:int > bar:float', 'Can\'t compare int to float'];
         yield 'float > int' => ['foo:float > bar:int', 'Can\'t compare float to int'];
         yield 'string > string' => ['foo:string > bar:string', 'Can\'t compare string to string'];
@@ -530,6 +537,10 @@ final class ExpressionParserErrorTest extends TestCase
             ],
             [
                 '"foo" === 72 + 23',
+                '          =======',
+            ],
+            [
+                '"foo" === 72 * 23',
                 '          =======',
             ],
             [

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -85,7 +85,8 @@ final class ExpressionParserTest extends TestCase
                     Expr::get('c', Type::int()),
                 ),
             ],
-            // + and - share the additive level, so a chain mixing the two is still left-associative across it.
+            // + and - share the additive level, * the multiplicative one, so a chain mixing operators of one level
+            // is still left-associative across them.
             [
                 'a:int + b:int + c:int',
                 Expr::add(Expr::add(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
@@ -97,6 +98,10 @@ final class ExpressionParserTest extends TestCase
             [
                 'a:int - b:int + c:int',
                 Expr::add(Expr::subtract(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
+            ],
+            [
+                'a:int * b:int * c:int',
+                Expr::multiply(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
             ],
             ['"💩"', Expr::literal('💩')],
             ['foo:map<string, int>', Expr::get('foo', Type::mapOf(Type::string(), Type::int()))],
@@ -169,6 +174,20 @@ final class ExpressionParserTest extends TestCase
                 'a:bool === (b:int > c:int)',
                 Expr::eq(Expr::get('a', $b), Expr::gt(Expr::get('b', $i), Expr::get('c', $i))),
             ],
+            // Multiplicative binds tighter than additive.
+            [
+                'a:int + b:int * c:int',
+                Expr::add(Expr::get('a', $i), Expr::multiply(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
+                'a:int * b:int - c:int',
+                Expr::subtract(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
+            ],
+            // ...and on the right of - just like on the right of +: a multiplicative subtrahend prints bare.
+            [
+                'a:int - b:int * c:int',
+                Expr::subtract(Expr::get('a', $i), Expr::multiply(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
             // Unary binds tighter than additive, so this subtracts a negation rather than negating a subtraction.
             [
                 'a:int - -b:int',
@@ -177,6 +196,11 @@ final class ExpressionParserTest extends TestCase
             [
                 'a:int + -b:int',
                 Expr::add(Expr::get('a', $i), Expr::negative(Expr::get('b', $i))),
+            ],
+            // ...and tighter than multiplicative, so this multiplies by a negation.
+            [
+                'a:int * -b:int',
+                Expr::multiply(Expr::get('a', $i), Expr::negative(Expr::get('b', $i))),
             ],
             // Operators are allowed wherever an expression is expected, not just at the top level.
             [
@@ -243,12 +267,28 @@ final class ExpressionParserTest extends TestCase
                 Expr::add(Expr::get('a', $i), Expr::add(Expr::get('b', $i), Expr::get('c', $i))),
             ],
             [
+                'a:int * (b:int * c:int)',
+                Expr::multiply(Expr::get('a', $i), Expr::multiply(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
+                '(a:int + b:int) * c:int',
+                Expr::multiply(Expr::add(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
+            ],
+            [
+                'a:int * (b:int + c:int)',
+                Expr::multiply(Expr::get('a', $i), Expr::add(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
                 'a:int - (b:int + c:int)',
                 Expr::subtract(Expr::get('a', $i), Expr::add(Expr::get('b', $i), Expr::get('c', $i))),
             ],
             [
                 '-(a:int - b:int)',
                 Expr::negative(Expr::subtract(Expr::get('a', $i), Expr::get('b', $i))),
+            ],
+            [
+                '-(a:int * b:int)',
+                Expr::negative(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i))),
             ],
             // === and > are non-associative, so a parenthesized comparison is the only way one ends up inside another.
             [
@@ -264,6 +304,10 @@ final class ExpressionParserTest extends TestCase
             [
                 '(a:int - b:int).abs:int()',
                 Expr::subtract(Expr::get('a', $i), Expr::get('b', $i))->call('abs', $i, []),
+            ],
+            [
+                '(a:int * b:int).abs:int()',
+                Expr::multiply(Expr::get('a', $i), Expr::get('b', $i))->call('abs', $i, []),
             ],
             [
                 '(-a:int).abs:int()',
@@ -310,10 +354,11 @@ final class ExpressionParserTest extends TestCase
             ['foo:int-2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
             ['foo:int -2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
             ['foo:int- 2', Expr::subtract(Expr::get('foo', Type::int()), Expr::literal(2))],
-            // The plus doesn't double as a literal's sign the way the minus does, so whitespace has nothing to
-            // decide; it just must not matter.
+            // The other arithmetic operators don't double as a literal's sign, so whitespace has nothing to decide;
+            // it just must not matter.
             ['foo:int+2', Expr::add(Expr::get('foo', Type::int()), Expr::literal(2))],
             ['foo:int +2', Expr::add(Expr::get('foo', Type::int()), Expr::literal(2))],
+            ['foo:int*2', Expr::multiply(Expr::get('foo', Type::int()), Expr::literal(2))],
             // Trailing commas are allowed in argument and list literal element lists.
             [
                 'foo:string.substr:string(0, 3,)',
@@ -371,6 +416,13 @@ final class ExpressionParserTest extends TestCase
                 '(a:int + b:int) + c:int',
                 Expr::add(
                     Expr::add(Expr::get('a', Type::int()), Expr::get('b', Type::int())),
+                    Expr::get('c', Type::int()),
+                ),
+            ],
+            [
+                '(a:int * b:int) * c:int',
+                Expr::multiply(
+                    Expr::multiply(Expr::get('a', Type::int()), Expr::get('b', Type::int())),
                     Expr::get('c', Type::int()),
                 ),
             ],

--- a/tests/unit/cases/multiply/in-lambda-body.txt
+++ b/tests/unit/cases/multiply/in-lambda-body.txt
@@ -1,0 +1,7 @@
+ints:list<int>.map:list<int>(|i| i:int * 2)
+-- Input --
+{
+  ints: [1, 2, 3],
+}
+-- Output --
+[2, 4, 6]

--- a/tests/unit/cases/multiply/in-struct-field.txt
+++ b/tests/unit/cases/multiply/in-struct-field.txt
@@ -1,0 +1,8 @@
+{total: a:int * b:int}
+-- Input --
+{
+  a: 6,
+  b: 7,
+}
+-- Output --
+{total: 42}

--- a/tests/unit/cases/parentheses/additive-groups-multiplicative.txt
+++ b/tests/unit/cases/parentheses/additive-groups-multiplicative.txt
@@ -1,0 +1,9 @@
+(a:int + b:int) * c:int
+-- Input --
+{
+  a: 2,
+  b: 3,
+  c: 4,
+}
+-- Output --
+20

--- a/tests/unit/cases/precedence/multiplicative-after-additive.txt
+++ b/tests/unit/cases/precedence/multiplicative-after-additive.txt
@@ -1,0 +1,9 @@
+a:int * b:int + c:int
+-- Input --
+{
+  a: 2,
+  b: 3,
+  c: 4,
+}
+-- Output --
+10

--- a/tests/unit/cases/precedence/multiplicative-before-additive.txt
+++ b/tests/unit/cases/precedence/multiplicative-before-additive.txt
@@ -1,0 +1,9 @@
+a:int + b:int * c:int
+-- Input --
+{
+  a: 2,
+  b: 3,
+  c: 4,
+}
+-- Output --
+14


### PR DESCRIPTION

Multiplication binds tighter than addition and subtraction, which the cascade has no level for yet: additive delegated straight to unary. Slot a multiplicative level between the two, so `a:int + b:int * c:int` is `a:int + (b:int * c:int)` and the grouping is expressed by the call graph rather than by anything a level has to know about its neighbors. `Precedence` gains the matching case, which is what decides where a printed expression needs parentheses: a multiplicative operand of an additive operator prints bare, an additive operand of a multiplicative one gets a pair.

`Multiply` goes on the `Arithmetic` base, so it decides whether its int result exists before computing it. The two multiplicands that land exactly on a bound are the quotients of the bounds by the multiplier — `intdiv()` truncates toward zero, which is toward the inside of whichever bound the product approaches, so each is exactly the last multiplicand that still fits. A negative multiplier reverses which of them is the upper and which the lower, so they're ordered by value rather than by which limit they came from. The two multipliers that can't be asked are handled first: zero would make `intdiv()` throw, and multiplying by `-1` is negating, which is where the one missing product is.

Split from #76.