### PR TITLE
Add the arithmetic operators / and %, which answer an Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,29 +62,51 @@ See [Types](#types)
 
 Both operands must be of the same type.
 
-| Operator | Description           | Example                  | Note                                      |
-|----------|-----------------------|--------------------------|-------------------------------------------|
-| `===`    | Equality              | `foo:string === "bar"`   |                                           |
-| `!==`    | Inequality            | `foo:string !== "bar"`   |                                           |
-| `-`      | Subtraction           | `foo:int - bar:int`      | Operands must be of type `int` or `float` |
-| `+`      | Addition              | `foo:int + bar:int`      | Operands must be of type `int` or `float` |
-| `*`      | Multiplication        | `foo:int * bar:int`      | Operands must be of type `int` or `float` |
-| `>`      | Greater than          | `foo:int > bar:int`      | Operands must be of type `int` or `float` |
-| `>=`     | Greater than or equal | `foo:int >= bar:int`     | Operands must be of type `int` or `float` |
-| `<`      | Less than             | `foo:int < bar:int`      | Operands must be of type `int` or `float` |
-| `<=`     | Less than or equal    | `foo:int <= bar:int`     | Operands must be of type `int` or `float` |
-| `\|\|`   | Logical OR            | `foo:bool \|\| bar:bool` | Operands must be of type `bool`           |
-| &&       | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`           |
+| Operator | Description           | Example                  | Note                                            |
+|----------|-----------------------|--------------------------|-------------------------------------------------|
+| `===`    | Equality              | `foo:string === "bar"`   |                                                 |
+| `!==`    | Inequality            | `foo:string !== "bar"`   |                                                 |
+| `-`      | Subtraction           | `foo:int - bar:int`      | Operands must be of type `int` or `float`       |
+| `+`      | Addition              | `foo:int + bar:int`      | Operands must be of type `int` or `float`       |
+| `*`      | Multiplication        | `foo:int * bar:int`      | Operands must be of type `int` or `float`       |
+| `/`      | Division              | `foo:int / bar:int`      | See [Division and modulo](#division-and-modulo) |
+| `%`      | Modulo                | `foo:int % bar:int`      | See [Division and modulo](#division-and-modulo) |
+| `>`      | Greater than          | `foo:int > bar:int`      | Operands must be of type `int` or `float`       |
+| `>=`     | Greater than or equal | `foo:int >= bar:int`     | Operands must be of type `int` or `float`       |
+| `<`      | Less than             | `foo:int < bar:int`      | Operands must be of type `int` or `float`       |
+| `<=`     | Less than or equal    | `foo:int <= bar:int`     | Operands must be of type `int` or `float`       |
+| `\|\|`   | Logical OR            | `foo:bool \|\| bar:bool` | Operands must be of type `bool`                 |
+| &&       | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`                 |
 
 Equality is spelled `===`, so inequality is `!==`; there is no `==` or `!=`.
 
 Where's the rest? We're implementing more as we need them.
 
+#### Division and modulo
+
+Like the other arithmetic operators, `/` and `%` take two operands of the same numeric type — but the result is an
+`Option` of that type: `int / int` is an `Option<int>`. A zero divisor makes it `none` rather than an error, and `/`
+has a second `none`: `PHP_INT_MIN / -1`, the one `int` quotient that doesn't fit in an `int`. `%` doesn't share it —
+`PHP_INT_MIN % -1` is `0`, a remainder like any other. Get at the value the same way you would with `head`:
+
+```
+(a:int / b:int).unwrap:int()
+(a:int / b:int).isSome:bool()
+(i:int % 3).unwrap:int() === 0
+```
+
+`unwrap` fails evaluation on `none`, so use it where a zero divisor can't happen or should be loud; check with
+`isSome` where it's a case to handle. Because the result is an `Option`, it doesn't chain into further arithmetic or
+comparison without an `unwrap`: `a:int / b:int / c:int` is a type error.
+
+An `int` quotient truncates toward zero: `7 / 2` is `3`, and `-7 / 2` is `-3`. The remainder takes the dividend's
+sign: `-7 % 3` is `-1`. A `float` remainder is PHP's `fmod()`.
+
 #### Int overflow
 
 PHP's `int` arithmetic isn't closed: a sum, difference or product past the `int` range evaluates to a `float` rather
-than wrapping. An `int`-typed expression that answered one would be handing back a value of a type it doesn't have, so each
-operator decides up front whether its result exists and fails evaluation when it doesn't:
+than wrapping. An `int`-typed expression that answered one would be handing back a value of a type it doesn't have, so
+each operator decides up front whether its result exists and fails evaluation when it doesn't:
 
 ```
 a:int + b:int
@@ -92,27 +114,31 @@ a:int + b:int
 
 with `a` at `PHP_INT_MAX` and `b` at `1` is an evaluation error, not `9.2233720368548E+18`. `-`, `*` and unary `-` work
 the same way. Evaluating an `int`-typed expression therefore gives you an `int` or nothing at all — the widened value is
-never computed, so it can't reach a caller or quietly widen the operator above it either. `float` arithmetic has no
-such wall: it goes to `INF`, as it does in PHP.
+never computed, so it can't reach a caller or quietly widen the operator above it either.
+
+Overflow is not an `Option` case. `/` and `%` give `none` where the operands are fine but the result doesn't exist — a
+zero divisor, or `PHP_INT_MIN / -1` — which is a case worth handling in an expression. A sum that leaves the range is
+instead a mismatch between the values and the type they were declared with, so it's an error to fix rather than a branch
+to write. `float` arithmetic has neither: it goes to `INF`, as it does in PHP.
 
 #### Precedence
 
 Operators bind from tightest to loosest in this order:
 
-| Operator                            | Associativity   |
-|-------------------------------------|-----------------|
-| `.` (field, method)                 | Left            |
-| `-` (negation)                      | Right           |
-| `*`                                 | Left            |
-| `-` (subtraction), `+`              | Left            |
-| `===`, `!==`, `>`, `>=`, `<`, `<=`  | Non-associative |
-| `&&`                                | Left            |
-| `\|\|`                              | Left            |
+| Operator                           | Associativity   |
+|------------------------------------|-----------------|
+| `.` (field, method)                | Left            |
+| `-` (negation)                     | Right           |
+| `*`, `/`, `%`                      | Left            |
+| `-` (subtraction), `+`             | Left            |
+| `===`, `!==`, `>`, `>=`, `<`, `<=` | Non-associative |
+| `&&`                               | Left            |
+| `\|\|`                             | Left            |
 
 As in most languages, `&&` binds tighter than `||`, so `a:bool && b:bool || c:bool` means
-`(a:bool && b:bool) || c:bool`; `*` binds tighter than `+` and binary `-`, so `a:int + b:int * c:int` means
-`a:int + (b:int * c:int)`. Operators that share a level are left-associative across it: `a:int - b:int + c:int` means
-`(a:int - b:int) + c:int`.
+`(a:bool && b:bool) || c:bool`; `*`, `/` and `%` bind tighter than `+` and binary `-`, so `a:int + b:int * c:int`
+means `a:int + (b:int * c:int)`. Operators that share a level are left-associative across it:
+`a:int - b:int + c:int` means `(a:int - b:int) + c:int`.
 
 The comparison operators are non-associative: `a:int > b:int > c:int` is a syntax error rather than a comparison
 against the `bool` that the first comparison produces. Chain with `&&` instead.
@@ -126,7 +152,7 @@ a:bool && (b:bool || c:bool)
 (a:int - b:int) - c:int
 (a:int + b:int) * c:int
 (a:int > b:int) === c:bool
-(a:int - b:int).abs:int()
+(a:int / b:int).unwrap:int()
 ```
 
 Parentheses only group; they add no node of their own. Redundant ones — a group the precedence would have produced

--- a/src/Divide.php
+++ b/src/Divide.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+use function intdiv;
+
+/**
+ * The quotient of a division, truncated toward zero for int operands. Total, in the way {@see Division} describes: the
+ * quotients that don't exist are every zero divisor, plus PHP_INT_MIN / -1, the one int division whose result
+ * overflows int and the one input {@see intdiv()} throws for.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Divide extends Division
+{
+    #[Override]
+    public function token(): Token
+    {
+        return Token::Slash;
+    }
+
+    /**
+     * Dividing by -1 is negating, so the one nonzero divisor with a quotient that may not exist is handled by
+     * {@see IntArithmetic::negate()} — which is also the one input {@see intdiv()} throws for rather than answers.
+     */
+    #[Override]
+    protected function applyInt(int $dividend, int $divisor): int|null
+    {
+        return $divisor === -1 ? IntArithmetic::negate($dividend) : intdiv($dividend, $divisor);
+    }
+
+    #[Override]
+    protected function applyFloat(float $dividend, float $divisor): float
+    {
+        return $dividend / $divisor;
+    }
+}

--- a/src/Division.php
+++ b/src/Division.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Override;
+
+/**
+ * The quotient and the remainder of a division: the two operators whose result may not exist in the operand type, and
+ * which are therefore total in the same way. Both give an option of that type, and both answer none rather than
+ * throwing when the result doesn't exist — the same shape the `head` builtin gives an empty list. A zero divisor is
+ * the case they share; {@see Divide} has one more.
+ *
+ * Which of the two arithmetics either one is comes from the operands' declared type, never from what they evaluate to:
+ * the declared type is what {@see self::getType()} has already committed the result to, so deciding it any other way
+ * could answer an Option<int> with a float. Both operands are narrowed to the type they claim before the result is
+ * asked to exist, the same way {@see Arithmetic} — the other half of the arithmetic, whose result is of the operand
+ * type rather than an option of it — narrows its own.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+abstract class Division extends BinaryOperator
+{
+    #[Override]
+    final public function evaluate(Scope $scope): int|float|null
+    {
+        if ($this->left->matchesType(Type::float())) {
+            $dividend = Operand::float($this->left->evaluate($scope));
+            $divisor = Operand::float($this->right->evaluate($scope));
+            return $divisor === 0.0 ? null : $this->applyFloat($dividend, $divisor);
+        }
+        $dividend = Operand::int($this->left->evaluate($scope));
+        $divisor = Operand::int($this->right->evaluate($scope));
+        return $divisor === 0 ? null : $this->applyInt($dividend, $divisor);
+    }
+
+    #[Override]
+    final public function getType(): Type
+    {
+        return Type::option($this->left->getType());
+    }
+
+    /**
+     * The int result for a divisor already known to be nonzero, or null if it still doesn't exist in int.
+     */
+    abstract protected function applyInt(int $dividend, int $divisor): int|null;
+
+    /**
+     * The float result for a divisor already known to be nonzero.
+     */
+    abstract protected function applyFloat(float $dividend, float $divisor): float;
+}

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -160,6 +160,34 @@ final class Expr
         return new Multiply($multiplicand, $multiplier);
     }
 
+    /**
+     * The quotient's type is an option of the operands' type: division is total, and a zero divisor evaluates to none.
+     * See {@see Divide}.
+     */
+    public static function divide(Expression $dividend, Expression $divisor): Divide
+    {
+        self::assertSameNumberType($dividend, $divisor, static fn(): string => sprintf(
+            'Can\'t divide %s by %s',
+            $dividend->getType(),
+            $divisor->getType(),
+        ));
+        return new Divide($dividend, $divisor);
+    }
+
+    /**
+     * The remainder's type is an option of the operands' type: modulo is total, and a zero divisor evaluates to none.
+     * See {@see Modulo}.
+     */
+    public static function modulo(Expression $dividend, Expression $divisor): Modulo
+    {
+        self::assertSameNumberType($dividend, $divisor, static fn(): string => sprintf(
+            'Can\'t take %s modulo %s',
+            $dividend->getType(),
+            $divisor->getType(),
+        ));
+        return new Modulo($dividend, $divisor);
+    }
+
     public static function gt(Expression $left, Expression $right): Gt
     {
         self::checkComparison(ComparisonOperator::GreaterThan, $left, $right);

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -38,6 +38,22 @@ abstract class Expression implements Stringable
         return Expr::multiply($this, $multiplier);
     }
 
+    /**
+     * The quotient is an option of the operands' type: none when the divisor evaluates to zero. See {@see Divide}.
+     */
+    public function divide(self $divisor): Divide
+    {
+        return Expr::divide($this, $divisor);
+    }
+
+    /**
+     * The remainder is an option of the operands' type: none when the divisor evaluates to zero. See {@see Modulo}.
+     */
+    public function modulo(self $divisor): Modulo
+    {
+        return Expr::modulo($this, $divisor);
+    }
+
     public function gt(self $right): Gt
     {
         return Expr::gt($this, $right);

--- a/src/Literal.php
+++ b/src/Literal.php
@@ -34,6 +34,13 @@ final class Literal extends AbstractLiteral
         $this->location = $location;
     }
 
+    /**
+     * The source spelling of a value, where it has one. `none` doesn't: {@see Type::fromValue()} reads PHP's null as
+     * the None type, and it prints here as `null` because that is what it is in PHP, but the language has no null
+     * literal to read it back with. A none-valued expression therefore prints to something the parser rejects — the
+     * one value this produces that doesn't round-trip, and the reason the test cases that evaluate to none assert
+     * through `isSome` instead of naming the value.
+     */
     private static function dumpValue(mixed $value): string
     {
         if (is_string($value)) {

--- a/src/Modulo.php
+++ b/src/Modulo.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+use function fmod;
+
+/**
+ * The remainder of a division, taking the dividend's sign. Total, in the way {@see Division} describes, and a zero
+ * divisor is the only operand pair without a remainder — the division whose quotient overflows int still has one,
+ * since PHP_INT_MIN % -1 is 0. A float remainder is {@see fmod()}, whose NAN-on-zero quirk stays inside: the divisor
+ * is checked before it's called.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Modulo extends Division
+{
+    #[Override]
+    public function token(): Token
+    {
+        return Token::Percent;
+    }
+
+    #[Override]
+    protected function applyInt(int $dividend, int $divisor): int
+    {
+        return $dividend % $divisor;
+    }
+
+    #[Override]
+    protected function applyFloat(float $dividend, float $divisor): float
+    {
+        return fmod($dividend, $divisor);
+    }
+}

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -173,7 +173,7 @@ final class ExpressionParser
     }
 
     /**
-     * a:int * b:int * c:int
+     * a:int * b:int / c:int
      * =====================
      */
     private function parseMultiplicative(): Expression
@@ -182,6 +182,8 @@ final class ExpressionParser
         while (true) {
             $build = match ($this->nextToken()) {
                 Token::Asterisk => $left->multiply(...),
+                Token::Slash => $left->divide(...),
+                Token::Percent => $left->modulo(...),
                 default => null,
             };
             if ($build === null) {

--- a/src/Parser/Token.php
+++ b/src/Parser/Token.php
@@ -32,6 +32,8 @@ enum Token: string
     case Minus = '-';
     case Plus = '+';
     case Asterisk = '*';
+    case Slash = '/';
+    case Percent = '%';
     case Arrow = '->';
 
     /**

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -64,6 +64,8 @@ final class Tokenizer
                 ',' => Token::Comma,
                 '+' => Token::Plus,
                 '*' => Token::Asterisk,
+                '/' => Token::Slash,
+                '%' => Token::Percent,
                 '[' => Token::OpenBracket,
                 ']' => Token::CloseBracket,
                 '{' => Token::OpenBrace,

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -130,7 +130,7 @@ enum Precedence: int
             Token::TripleEquals, Token::NotEquals, Token::CloseAngle, Token::OpenAngle,
             Token::GreaterThanEquals, Token::LessThanEquals => self::Comparison,
             Token::Plus, Token::Minus => self::Additive,
-            Token::Asterisk => self::Multiplicative,
+            Token::Asterisk, Token::Slash, Token::Percent => self::Multiplicative,
             default => throw new LogicException(sprintf('%s is not a binary operator', $token->value)),
         };
     }

--- a/tests/unit/AssertsEvaluatedValues.php
+++ b/tests/unit/AssertsEvaluatedValues.php
@@ -14,9 +14,9 @@ use function is_object;
  * included.
  *
  * assertEquals() is too weak to say that. It can't tell 0 from null, null from false, or 24 from 24.0 — and those are
- * exactly the distinctions the evaluation cases exist to pin. `isSome` on a none answers false rather than the null
- * inside it, and an int subtraction gives back an int rather than a float: under assertEquals either case passes
- * whether or not the library still holds up its end.
+ * exactly the distinctions the evaluation cases exist to pin. `PHP_INT_MIN % -1` is 0 rather than none, an int
+ * operation gives back an int, and a zero divisor gives none rather than a number: under assertEquals every one of
+ * those cases passes whether or not the library still holds up its end.
  *
  * Structs are the one place identity isn't available: the library builds its own objects, so an expectation is never
  * the same instance as the result. They are therefore compared field by field, and lists element by element, until the

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -8,6 +8,7 @@ use Eventjet\Ausdruck\Add;
 use Eventjet\Ausdruck\And_;
 use Eventjet\Ausdruck\Call;
 use Eventjet\Ausdruck\ComparisonOperator;
+use Eventjet\Ausdruck\Divide;
 use Eventjet\Ausdruck\Expr;
 use Eventjet\Ausdruck\Expression;
 use Eventjet\Ausdruck\FieldAccess;
@@ -15,6 +16,7 @@ use Eventjet\Ausdruck\Get;
 use Eventjet\Ausdruck\Lambda;
 use Eventjet\Ausdruck\ListLiteral;
 use Eventjet\Ausdruck\Literal;
+use Eventjet\Ausdruck\Modulo;
 use Eventjet\Ausdruck\Multiply;
 use Eventjet\Ausdruck\Negative;
 use Eventjet\Ausdruck\Or_;
@@ -59,6 +61,14 @@ final class ExpressionComparisonTest extends TestCase
         yield [
             Expr::multiply(Expr::literal(1), Expr::literal(2)),
             Expr::multiply(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield [
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield [
+            Expr::modulo(Expr::literal(1), Expr::literal(2)),
+            Expr::modulo(Expr::literal(1), Expr::literal(2)),
         ];
         yield [
             Expr::gt(Expr::literal(1), Expr::literal(2)),
@@ -240,6 +250,30 @@ final class ExpressionComparisonTest extends TestCase
         yield Multiply::class . ': multiplier is different' => [
             Expr::multiply(Expr::literal(1), Expr::literal(2)),
             Expr::multiply(Expr::literal(1), Expr::literal(1)),
+        ];
+        yield Multiply::class . ' and ' . Divide::class => [
+            Expr::multiply(Expr::literal(1), Expr::literal(2)),
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield Divide::class . ': dividend is different' => [
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+            Expr::divide(Expr::literal(2), Expr::literal(2)),
+        ];
+        yield Divide::class . ': divisor is different' => [
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+            Expr::divide(Expr::literal(1), Expr::literal(1)),
+        ];
+        yield Divide::class . ' and ' . Modulo::class => [
+            Expr::divide(Expr::literal(1), Expr::literal(2)),
+            Expr::modulo(Expr::literal(1), Expr::literal(2)),
+        ];
+        yield Modulo::class . ': dividend is different' => [
+            Expr::modulo(Expr::literal(1), Expr::literal(2)),
+            Expr::modulo(Expr::literal(2), Expr::literal(2)),
+        ];
+        yield Modulo::class . ': divisor is different' => [
+            Expr::modulo(Expr::literal(1), Expr::literal(2)),
+            Expr::modulo(Expr::literal(1), Expr::literal(1)),
         ];
         yield Call::class . ': target is different' => [
             Expr::literal(1)->call('foo', Type::int(), []),

--- a/tests/unit/ExpressionTest.php
+++ b/tests/unit/ExpressionTest.php
@@ -141,13 +141,39 @@ final class ExpressionTest extends TestCase
             ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MIN, -2), 'b' => -2]), PHP_INT_MIN],
             ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MAX, 2), 'b' => 2]), PHP_INT_MAX - 1],
             ['a:int * b:int', new Scope(['a' => intdiv(PHP_INT_MAX, -2), 'b' => -2]), PHP_INT_MAX - 1],
-            // Negation is arithmetic too: PHP_INT_MIN is the one int it has no answer for, one step past the boundary.
             ['-a:int', new Scope(['a' => PHP_INT_MAX]), -PHP_INT_MAX],
             ['-a:int', new Scope(['a' => PHP_INT_MIN + 1]), PHP_INT_MAX],
             ['-a:float', new Scope(['a' => 1.5]), -1.5],
+            // An int quotient truncates toward zero.
+            ['a:int / b:int', new Scope(['a' => 7, 'b' => 2]), 3],
+            ['a:int / b:int', new Scope(['a' => -7, 'b' => 2]), -3],
+            ['a:float / b:float', new Scope(['a' => 7.0, 'b' => 2.0]), 3.5],
+            // A zero divisor makes the quotient none, whatever the number type. Negative zero counts as zero.
+            ['a:int / b:int', new Scope(['a' => 1, 'b' => 0]), null],
+            ['a:float / b:float', new Scope(['a' => 1.0, 'b' => 0.0]), null],
+            ['x:float / negZero:float', new Scope(['x' => 1.0, 'negZero' => -0.0]), null],
+            // PHP_INT_MIN / -1 is the other quotient int doesn't have: it overflows by one, and intdiv() would throw.
+            // Its neighbors — same dividend, same divisor — divide normally, and the matching remainder exists: it's 0.
+            ['a:int / b:int', new Scope(['a' => PHP_INT_MIN, 'b' => -1]), null],
+            ['a:int / b:int', new Scope(['a' => PHP_INT_MIN, 'b' => 1]), PHP_INT_MIN],
+            ['a:int / b:int', new Scope(['a' => 7, 'b' => -1]), -7],
+            ['a:int % b:int', new Scope(['a' => PHP_INT_MIN, 'b' => -1]), 0],
+            ['(a:int / b:int).isSome()', new Scope(['a' => 1, 'b' => 0]), false],
+            ['(a:int / b:int).isSome()', new Scope(['a' => 1, 'b' => 2]), true],
+            ['(a:int / b:int).unwrap:int()', new Scope(['a' => 9, 'b' => 2]), 4],
+            // The remainder takes the dividend's sign, for floats (fmod) just like for ints (%).
+            ['a:int % b:int', new Scope(['a' => 7, 'b' => 3]), 1],
+            ['a:int % b:int', new Scope(['a' => -7, 'b' => 3]), -1],
+            ['a:float % b:float', new Scope(['a' => 5.5, 'b' => 2.0]), 1.5],
+            ['a:float % b:float', new Scope(['a' => -5.5, 'b' => 2.0]), -1.5],
+            ['a:int % b:int', new Scope(['a' => 7, 'b' => 0]), null],
+            ['a:float % b:float', new Scope(['a' => 5.5, 'b' => 0.0]), null],
+            ['(a:int % 3).unwrap:int() === 0', new Scope(['a' => 9]), true],
+            ['(a:int % 3).unwrap:int() === 0', new Scope(['a' => 10]), false],
             ['a:int + b:int * c:int', new Scope(['a' => 2, 'b' => 3, 'c' => 4]), 14],
             ['(a:int + b:int) * c:int', new Scope(['a' => 2, 'b' => 3, 'c' => 4]), 20],
             ['a:int - b:int + c:int', new Scope(['a' => 10, 'b' => 3, 'c' => 4]), 11],
+            ['a:int * b:int / c:int', new Scope(['a' => 10, 'b' => 3, 'c' => 4]), 7],
             ['"foo" === "bar"', new Scope(), false],
             ['"foo" === "foo"', new Scope(), true],
             ['foo:any === bar:any', new Scope(['foo' => 12.34, 'bar' => 12.34]), true],
@@ -442,6 +468,17 @@ final class ExpressionTest extends TestCase
             new Scope(['foo' => []]),
             'Expected variable "foo" to be of type string, got array: Expected string, got list<never>',
         ];
+        // Operands evaluate left to right, so the dividend runs even when the divisor turns out to be zero.
+        yield 'Division evaluates its dividend even when the divisor is zero' => [
+            ['a:int / b:int'],
+            new Scope(['b' => 0]),
+            'Unknown variable "a"',
+        ];
+        yield 'Unwrapping a none quotient' => [
+            ['(a:int / b:int).unwrap:int()'],
+            new Scope(['a' => 1, 'b' => 0]),
+            'Expected int, got None',
+        ];
         // PHP's int arithmetic isn't closed: a sum, difference or product past the range evaluates to a float rather
         // than wrapping. An int-typed expression that answered one would be handing back a value of a type it doesn't
         // have, so every operator decides up front whether its int result exists and fails when it doesn't. The
@@ -489,7 +526,7 @@ final class ExpressionTest extends TestCase
             'a:int * b:int leaves the int range',
         ];
         // Negating and multiplying by -1 are the same operation, and PHP_INT_MIN is the one int neither has an answer
-        // for: -PHP_INT_MIN is one past PHP_INT_MAX.
+        // for: -PHP_INT_MIN is one past PHP_INT_MAX. It's the quotient Divide is missing too.
         yield 'Product of PHP_INT_MIN and -1' => [
             ['a:int * b:int'],
             new Scope(['a' => PHP_INT_MIN, 'b' => -1]),
@@ -503,8 +540,20 @@ final class ExpressionTest extends TestCase
         // The operator whose result left the range is the one blamed, wherever it sits: an operand can't reach the
         // operator above it already widened, so no one else has to report the overflow second-hand.
         yield 'The operator that overflowed is the one blamed, not the one above it' => [
-            ['(a:int + b:int) * c:int'],
+            ['(a:int + b:int) / c:int'],
             new Scope(['a' => PHP_INT_MAX, 'b' => 1, 'c' => 2]),
+            'a:int + b:int leaves the int range',
+        ];
+        yield 'The operator that overflowed is the one blamed, on either side' => [
+            ['a:int % (b:int * c:int)'],
+            new Scope(['a' => 1, 'b' => PHP_INT_MAX, 'c' => 2]),
+            'b:int * c:int leaves the int range',
+        ];
+        // Operands evaluate before the quotient is asked to exist, so an overflow can't hide behind a divisor that
+        // happens to be zero.
+        yield 'Overflow is reported rather than excused by a zero divisor' => [
+            ['(a:int + b:int) / c:int'],
+            new Scope(['a' => PHP_INT_MAX, 'b' => 1, 'c' => 0]),
             'a:int + b:int leaves the int range',
         ];
     }
@@ -579,6 +628,10 @@ final class ExpressionTest extends TestCase
         yield 'Add floats' => ['a:float + b:float', Type::float()];
         yield 'Multiply ints' => ['a:int * b:int', Type::int()];
         yield 'Multiply floats' => ['a:float * b:float', Type::float()];
+        yield 'Divide ints' => ['a:int / b:int', Type::option(Type::int())];
+        yield 'Divide floats' => ['a:float / b:float', Type::option(Type::float())];
+        yield 'Modulo ints' => ['a:int % b:int', Type::option(Type::int())];
+        yield 'Modulo floats' => ['a:float % b:float', Type::option(Type::float())];
     }
 
     /**

--- a/tests/unit/Parser/ExpressionParserErrorTest.php
+++ b/tests/unit/Parser/ExpressionParserErrorTest.php
@@ -70,6 +70,8 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'missing right hand side of minus' => ['foo:int -'];
         yield 'missing right hand side of plus' => ['foo:int +'];
         yield 'missing right hand side of star' => ['foo:int *'];
+        yield 'missing right hand side of slash' => ['foo:int /'];
+        yield 'missing right hand side of percent' => ['foo:int %'];
         yield 'missing left hand side of plus' => ['+ foo:int', 'Expected expression, got +'];
         yield 'missing left hand side of star' => ['* foo:int', 'Expected expression, got *'];
         // Unlike -, + is not a unary operator.
@@ -178,6 +180,26 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'multiply string by string' => ['foo:string * bar:string', 'Can\'t multiply string by string'];
         yield 'multiply string by int' => ['foo:string * bar:int', 'Can\'t multiply string by int'];
         yield 'multiply int by string' => ['foo:int * bar:string', 'Can\'t multiply int by string'];
+        yield 'divide int by float' => ['foo:int / bar:float', 'Can\'t divide int by float'];
+        yield 'divide float by int' => ['foo:float / bar:int', 'Can\'t divide float by int'];
+        yield 'divide string by string' => ['foo:string / bar:string', 'Can\'t divide string by string'];
+        yield 'divide string by int' => ['foo:string / bar:int', 'Can\'t divide string by int'];
+        yield 'divide int by string' => ['foo:int / bar:string', 'Can\'t divide int by string'];
+        yield 'int modulo float' => ['foo:int % bar:float', 'Can\'t take int modulo float'];
+        yield 'float modulo int' => ['foo:float % bar:int', 'Can\'t take float modulo int'];
+        yield 'string modulo string' => ['foo:string % bar:string', 'Can\'t take string modulo string'];
+        yield 'string modulo int' => ['foo:string % bar:int', 'Can\'t take string modulo int'];
+        yield 'int modulo string' => ['foo:int % bar:string', 'Can\'t take int modulo string'];
+        // A quotient is an Option of the operand type, so it doesn't chain into further arithmetic, comparison or
+        // negation without an unwrap.
+        yield 'chained division' => ['a:int / b:int / c:int', 'Can\'t divide Option<int> by int'];
+        yield 'chained modulo' => ['a:int % b:int % c:int', 'Can\'t take Option<int> modulo int'];
+        yield 'subtracting from a quotient' => ['a:int / b:int - c:int', 'Can\'t subtract int from Option<int>'];
+        yield 'negating a quotient' => ['-(a:int / b:int)', 'Can\'t negate Option<int>'];
+        yield 'comparing a quotient to its operand type' => [
+            'a:int / b:int === 3',
+            'The expressions of both sides of === must be of the same type. Left: Option<int>, right: int',
+        ];
         yield 'int > float' => ['foo:int > bar:float', 'Can\'t compare int to float'];
         yield 'float > int' => ['foo:float > bar:int', 'Can\'t compare float to int'];
         yield 'string > string' => ['foo:string > bar:string', 'Can\'t compare string to string'];
@@ -541,6 +563,14 @@ final class ExpressionParserErrorTest extends TestCase
             ],
             [
                 '"foo" === 72 * 23',
+                '          =======',
+            ],
+            [
+                '"foo" === 72 / 23',
+                '          =======',
+            ],
+            [
+                '"foo" === 72 % 23',
                 '          =======',
             ],
             [

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -85,8 +85,8 @@ final class ExpressionParserTest extends TestCase
                     Expr::get('c', Type::int()),
                 ),
             ],
-            // + and - share the additive level, * the multiplicative one, so a chain mixing operators of one level
-            // is still left-associative across them.
+            // + and - share the additive level, * / % the multiplicative one, so a chain mixing operators of one
+            // level is still left-associative across them.
             [
                 'a:int + b:int + c:int',
                 Expr::add(Expr::add(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
@@ -102,6 +102,14 @@ final class ExpressionParserTest extends TestCase
             [
                 'a:int * b:int * c:int',
                 Expr::multiply(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
+            ],
+            [
+                'a:int * b:int / c:int',
+                Expr::divide(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
+            ],
+            [
+                'a:int * b:int % c:int',
+                Expr::modulo(Expr::multiply(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $i)),
             ],
             ['"💩"', Expr::literal('💩')],
             ['foo:map<string, int>', Expr::get('foo', Type::mapOf(Type::string(), Type::int()))],
@@ -279,6 +287,20 @@ final class ExpressionParserTest extends TestCase
                 Expr::multiply(Expr::get('a', $i), Expr::add(Expr::get('b', $i), Expr::get('c', $i))),
             ],
             [
+                'a:int / (b:int * c:int)',
+                Expr::divide(Expr::get('a', $i), Expr::multiply(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
+                'a:int % (b:int - c:int)',
+                Expr::modulo(Expr::get('a', $i), Expr::subtract(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            // A multiplicative-level divisor keeps its parentheses too: dropped, a:int % b:int * c:int would re-parse
+            // as (a:int % b:int) * c:int — a different tree.
+            [
+                'a:int % (b:int * c:int)',
+                Expr::modulo(Expr::get('a', $i), Expr::multiply(Expr::get('b', $i), Expr::get('c', $i))),
+            ],
+            [
                 'a:int - (b:int + c:int)',
                 Expr::subtract(Expr::get('a', $i), Expr::add(Expr::get('b', $i), Expr::get('c', $i))),
             ],
@@ -299,6 +321,15 @@ final class ExpressionParserTest extends TestCase
                 '(a:int > b:int) === c:bool',
                 Expr::eq(Expr::gt(Expr::get('a', $i), Expr::get('b', $i)), Expr::get('c', $b)),
             ],
+            // A comparison is the only place a quotient appears as a bare operand — every arithmetic slot rejects an
+            // Option — so this is the one case that exercises the comparison level's left slot against a division.
+            [
+                'a:int / b:int === c:int / d:int',
+                Expr::eq(
+                    Expr::divide(Expr::get('a', $i), Expr::get('b', $i)),
+                    Expr::divide(Expr::get('c', $i), Expr::get('d', $i)),
+                ),
+            ],
             // A method can be called on a grouped expression, so the postfix dot has to parenthesize a target looser
             // than a call's own — everything from a subtraction down to a negation.
             [
@@ -308,6 +339,19 @@ final class ExpressionParserTest extends TestCase
             [
                 '(a:int * b:int).abs:int()',
                 Expr::multiply(Expr::get('a', $i), Expr::get('b', $i))->call('abs', $i, []),
+            ],
+            // The way to get at a quotient: / makes an Option, and isSome/unwrap are calls on it.
+            [
+                '(a:int / b:int).isSome:bool()',
+                Expr::divide(Expr::get('a', $i), Expr::get('b', $i))->call('isSome', $b, []),
+            ],
+            [
+                '(a:int / b:int).unwrap:int()',
+                Expr::divide(Expr::get('a', $i), Expr::get('b', $i))->call('unwrap', $i, []),
+            ],
+            [
+                '(a:int % b:int).unwrap:int()',
+                Expr::modulo(Expr::get('a', $i), Expr::get('b', $i))->call('unwrap', $i, []),
             ],
             [
                 '(-a:int).abs:int()',
@@ -359,6 +403,8 @@ final class ExpressionParserTest extends TestCase
             ['foo:int+2', Expr::add(Expr::get('foo', Type::int()), Expr::literal(2))],
             ['foo:int +2', Expr::add(Expr::get('foo', Type::int()), Expr::literal(2))],
             ['foo:int*2', Expr::multiply(Expr::get('foo', Type::int()), Expr::literal(2))],
+            ['foo:int/2', Expr::divide(Expr::get('foo', Type::int()), Expr::literal(2))],
+            ['foo:int%2', Expr::modulo(Expr::get('foo', Type::int()), Expr::literal(2))],
             // Trailing commas are allowed in argument and list literal element lists.
             [
                 'foo:string.substr:string(0, 3,)',

--- a/tests/unit/cases/divide/by-nonzero-is-some.txt
+++ b/tests/unit/cases/divide/by-nonzero-is-some.txt
@@ -1,0 +1,8 @@
+(a:int / b:int).isSome:bool()
+-- Input --
+{
+  a: 1,
+  b: 2,
+}
+-- Output --
+true

--- a/tests/unit/cases/divide/by-zero-is-none.txt
+++ b/tests/unit/cases/divide/by-zero-is-none.txt
@@ -1,0 +1,8 @@
+(a:int / b:int).isSome:bool()
+-- Input --
+{
+  a: 1,
+  b: 0,
+}
+-- Output --
+false

--- a/tests/unit/cases/divide/float.txt
+++ b/tests/unit/cases/divide/float.txt
@@ -1,0 +1,8 @@
+(a:float / b:float).unwrap:float()
+-- Input --
+{
+  a: 7.0,
+  b: 2.0,
+}
+-- Output --
+3.5

--- a/tests/unit/cases/divide/negative-truncates-toward-zero.txt
+++ b/tests/unit/cases/divide/negative-truncates-toward-zero.txt
@@ -1,0 +1,8 @@
+(a:int / b:int).unwrap:int()
+-- Input --
+{
+  a: -7,
+  b: 2,
+}
+-- Output --
+-3

--- a/tests/unit/cases/divide/truncates-toward-zero.txt
+++ b/tests/unit/cases/divide/truncates-toward-zero.txt
@@ -1,0 +1,8 @@
+(a:int / b:int).unwrap:int()
+-- Input --
+{
+  a: 7,
+  b: 2,
+}
+-- Output --
+3

--- a/tests/unit/cases/modulo/by-zero-is-none.txt
+++ b/tests/unit/cases/modulo/by-zero-is-none.txt
@@ -1,0 +1,8 @@
+(a:int % b:int).isSome:bool()
+-- Input --
+{
+  a: 5,
+  b: 0,
+}
+-- Output --
+false

--- a/tests/unit/cases/modulo/every-nth.txt
+++ b/tests/unit/cases/modulo/every-nth.txt
@@ -1,0 +1,7 @@
+(i:int % 3).unwrap:int() === 0
+-- Input --
+{
+  i: 9,
+}
+-- Output --
+true

--- a/tests/unit/cases/modulo/float.txt
+++ b/tests/unit/cases/modulo/float.txt
@@ -1,0 +1,8 @@
+(a:float % b:float).unwrap:float()
+-- Input --
+{
+  a: 5.5,
+  b: 2.0,
+}
+-- Output --
+1.5

--- a/tests/unit/cases/modulo/sign-of-dividend.txt
+++ b/tests/unit/cases/modulo/sign-of-dividend.txt
@@ -1,0 +1,8 @@
+(a:int % b:int).unwrap:int()
+-- Input --
+{
+  a: -7,
+  b: 3,
+}
+-- Output --
+-1


### PR DESCRIPTION

A quotient and a remainder are the two arithmetic results that may not exist for operands that are themselves fine: every zero divisor, plus `PHP_INT_MIN / -1`, the one int division whose result overflows `int` and the one input `intdiv()` throws for. Answering none rather than throwing makes both total, the same shape the `head` builtin already gives an empty list, so `/` and `%` give an `Option` of the operand type: `int / int` is an `Option<int>`.

That is a different totality from `Arithmetic`'s, whose result is of the operand type rather than an option of it, so the pair goes on its own `Division` base. Both narrow their operands to the type they claim before the result is asked to exist — which of the two arithmetics either one is comes from the operands' declared type, never from what they evaluate to, since the declared type is what `getType()` has already committed the result to.

Because the result is an `Option`, it doesn't chain into further arithmetic, comparison or negation without an unwrap: `a:int / b:int / c:int` is a type error, and `.unwrap:int()` or `.isSome:bool()` is how you get at the value. Modulo doesn't share the overflow case — `PHP_INT_MIN % -1` is `0`, a remainder like any other — so a zero divisor is the only pair it has no answer for. A float remainder is `fmod()`, whose NAN-on-zero quirk stays inside: the divisor is checked before it's called.

Split from #76.