### PR TITLE
Add the boolean negation operator !

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [Types](#types)
 
 ### Operators
 
-Both operands must be of the same type. `!` is the one that takes a single operand, and it goes in front of it.
+Operators take two operands of the same type, except `!`, which takes a single boolean and goes in front of it.
 
 | Operator | Description           | Example                  | Note                                            |
 |----------|-----------------------|--------------------------|-------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ See [Types](#types)
 
 ### Operators
 
-Operators take two operands of the same type, except `!`, which takes a single boolean and goes in front of it.
+Operators take two operands of the same type, except the two prefix operators: unary `-`, which takes a single number,
+and `!`, which takes a single boolean. Both go in front of their operand.
 
 | Operator | Description           | Example                  | Note                                            |
 |----------|-----------------------|--------------------------|-------------------------------------------------|
@@ -77,6 +78,7 @@ Operators take two operands of the same type, except `!`, which takes a single b
 | `<=`     | Less than or equal    | `foo:int <= bar:int`     | Operands must be of type `int` or `float`       |
 | `\|\|`   | Logical OR            | `foo:bool \|\| bar:bool` | Operands must be of type `bool`                 |
 | &&       | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`                 |
+| `-`      | Negation              | `-foo:int`               | The operand must be of type `int` or `float`    |
 | `!`      | Logical NOT           | `!foo:bool`              | The operand must be of type `bool`              |
 
 Equality is spelled `===`, so inequality is `!==`; there is no `==` or `!=`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [Types](#types)
 
 ### Operators
 
-Both operands must be of the same type.
+Both operands must be of the same type. `!` is the one that takes a single operand, and it goes in front of it.
 
 | Operator | Description           | Example                  | Note                                            |
 |----------|-----------------------|--------------------------|-------------------------------------------------|
@@ -77,8 +77,18 @@ Both operands must be of the same type.
 | `<=`     | Less than or equal    | `foo:int <= bar:int`     | Operands must be of type `int` or `float`       |
 | `\|\|`   | Logical OR            | `foo:bool \|\| bar:bool` | Operands must be of type `bool`                 |
 | &&       | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`                 |
+| `!`      | Logical NOT           | `!foo:bool`              | The operand must be of type `bool`              |
 
 Equality is spelled `===`, so inequality is `!==`; there is no `==` or `!=`.
+
+`!` binds tighter than every binary operator, so it negates the expression right next to it and nothing more:
+`!foo:bool && bar:bool` is `(!foo:bool) && bar:bool`. That includes calls and field access, which bind tighter still,
+so a call is negated whole:
+
+```
+!names:list<string>.contains:bool(needle:string)
+!(a:bool || b:bool)
+```
 
 Where's the rest? We're implementing more as we need them.
 
@@ -128,7 +138,7 @@ Operators bind from tightest to loosest in this order:
 | Operator                           | Associativity   |
 |------------------------------------|-----------------|
 | `.` (field, method)                | Left            |
-| `-` (negation)                     | Right           |
+| `-` (negation), `!`                | Right           |
 | `*`, `/`, `%`                      | Left            |
 | `-` (subtraction), `+`             | Left            |
 | `===`, `!==`, `>`, `>=`, `<`, `<=` | Non-associative |
@@ -153,6 +163,7 @@ a:bool && (b:bool || c:bool)
 (a:int + b:int) * c:int
 (a:int > b:int) === c:bool
 (a:int / b:int).unwrap:int()
+!(a:bool || b:bool)
 ```
 
 Parentheses only group; they add no node of their own. Redundant ones — a group the precedence would have produced

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -110,12 +110,31 @@ final class Expr
 
     public static function or_(Expression $left, Expression $right): Or_
     {
-        return new Or_(self::assertBoolean($left, '||', 'left'), self::assertBoolean($right, '||', 'right'));
+        return new Or_(
+            self::assertBoolean($left, 'The expression on the left side of ||'),
+            self::assertBoolean($right, 'The expression on the right side of ||'),
+        );
     }
 
     public static function and_(Expression $left, Expression $right): And_
     {
-        return new And_(self::assertBoolean($left, '&&', 'left'), self::assertBoolean($right, '&&', 'right'));
+        return new And_(
+            self::assertBoolean($left, 'The expression on the left side of &&'),
+            self::assertBoolean($right, 'The expression on the right side of &&'),
+        );
+    }
+
+    /**
+     * Nothing is folded here, unlike in {@see self::negative()}: `!true` stays a negation of the literal `true`. The
+     * language spells negative numbers, so a negated number literal has a literal to fold into; it spells no negative
+     * booleans, and `false` is not another spelling of `!true` but a different expression that evaluates the same.
+     */
+    public static function not(Expression $expression, Span|null $location = null): Not
+    {
+        return new Not(
+            self::assertBoolean($expression, 'The operand of !'),
+            $location ?? self::dummySpan(),
+        );
     }
 
     /**
@@ -441,20 +460,19 @@ final class Expr
     }
 
     /**
-     * @param 'left' | 'right' $side
+     * The rule the logical operators share: an operand of `&&`, `||` or `!` has to be boolean. Only how the offending
+     * operand is named differs between them—`!` has a single one, so it names no side—which is what $operand says, in
+     * the same division of labor {@see self::assertSameNumberType()} follows.
+     *
+     * @param string $operand How the operand is named in the error, e.g. `The operand of !`.
      */
-    private static function assertBoolean(Expression $expr, string $operator, string $side): Expression
+    private static function assertBoolean(Expression $expr, string $operand): Expression
     {
         if ($expr->matchesType(Type::bool())) {
             return $expr;
         }
         throw TypeError::create(
-            sprintf(
-                'The expression on the %s side of %s must be boolean, got %s',
-                $side,
-                $operator,
-                $expr->getType(),
-            ),
+            sprintf('%s must be boolean, got %s', $operand, $expr->getType()),
             $expr->location(),
         );
     }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -84,6 +84,11 @@ abstract class Expression implements Stringable
         return Expr::and_($this, $other);
     }
 
+    public function not(): self
+    {
+        return Expr::not($this);
+    }
+
     /**
      * Unlike the other builders, this one can't check its operands: there are no declarations here to look the
      * function's signature up in, so there is nothing to check the receiver and the arguments against. The call is

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -12,12 +12,6 @@ use Override;
  */
 final class Negative extends UnaryOperator
 {
-    #[Override]
-    public function token(): Token
-    {
-        return Token::Minus;
-    }
-
     /**
      * Negation is arithmetic too, and follows the rule {@see Arithmetic} sets: the operand is narrowed to the type it
      * claims, and an int result that doesn't exist is reported rather than widened. Which int result that is, and why,
@@ -37,5 +31,11 @@ final class Negative extends UnaryOperator
     public function getType(): Type
     {
         return $this->expression->getType();
+    }
+
+    #[Override]
+    protected function token(): Token
+    {
+        return Token::Minus;
     }
 }

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -4,26 +4,18 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
-
-use function sprintf;
 
 /**
  * Never wraps a {@see Literal}: {@see Expr::negative()} folds a negated number literal into a negative one.
  */
-final class Negative extends Expression
+final class Negative extends UnaryOperator
 {
-    use LocationTrait;
-
-    public function __construct(public readonly Expression $expression, Span $location)
+    #[Override]
+    public function token(): Token
     {
-        $this->location = $location;
-    }
-
-    public function __toString(): string
-    {
-        return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::Unary));
+        return Token::Minus;
     }
 
     /**
@@ -39,13 +31,6 @@ final class Negative extends Expression
         }
         $value = Operand::int($this->expression->evaluate($scope));
         return IntArithmetic::negate($value) ?? throw EvaluationError::outsideIntRange($this);
-    }
-
-    #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->expression->equals($other->expression);
     }
 
     #[Override]

--- a/src/Not.php
+++ b/src/Not.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+/**
+ * Boolean negation. Unlike {@see Negative}, it wraps a {@see Literal} like anything else: there is no negative boolean
+ * literal for {@see Expr::not()} to fold one into.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Not extends UnaryOperator
+{
+    #[Override]
+    public function token(): Token
+    {
+        return Token::Not;
+    }
+
+    #[Override]
+    public function evaluate(Scope $scope): bool
+    {
+        return !Operand::bool($this->expression->evaluate($scope));
+    }
+
+    /**
+     * Always bool, and the only unary operator whose type doesn't come from its operand — though it might as well,
+     * since {@see Expr::not()} accepts nothing but a bool.
+     */
+    #[Override]
+    public function getType(): Type
+    {
+        return Type::bool();
+    }
+}

--- a/src/Not.php
+++ b/src/Not.php
@@ -17,12 +17,6 @@ use Override;
 final class Not extends UnaryOperator
 {
     #[Override]
-    public function token(): Token
-    {
-        return Token::Not;
-    }
-
-    #[Override]
     public function evaluate(Scope $scope): bool
     {
         return !Operand::bool($this->expression->evaluate($scope));
@@ -36,5 +30,11 @@ final class Not extends UnaryOperator
     public function getType(): Type
     {
         return Type::bool();
+    }
+
+    #[Override]
+    protected function token(): Token
+    {
+        return Token::Not;
     }
 }

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -205,14 +205,15 @@ final class ExpressionParser
      * Negating a number literal produces a negative literal rather than a negation of a positive one, but that's
      * {@see Expr::negative()}'s job, not ours: folding it here would mean returning a primary without going through
      * parsePostfix(), and `-2 .abs:int()` would stop parsing.
+     *
+     * The consumed token is picked back up after the match rather than peeked before it, so this level decides whether
+     * to descend the same way its siblings do—one match on {@see self::nextToken()}, one exit. It is the only level
+     * that needs the operator itself and not just its kind, because a prefix operator's span is where the expression
+     * begins; having matched on it, we know it is there.
      */
     private function parseUnary(): Expression
     {
-        $operator = $this->tokens->peek();
-        if ($operator === null) {
-            return $this->parsePostfix();
-        }
-        $build = match ($operator->token) {
+        $build = match ($this->nextToken()) {
             Token::Minus => Expr::negative(...),
             Token::Not => Expr::not(...),
             default => null,
@@ -220,7 +221,8 @@ final class ExpressionParser
         if ($build === null) {
             return $this->parsePostfix();
         }
-        $this->tokens->next();
+        $operator = $this->tokens->next();
+        assert($operator !== null);
         $operand = $this->parseUnary();
         return $build($operand, $operator->location()->to($operand->location()));
     }

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -10,6 +10,7 @@ use Eventjet\Ausdruck\Expression;
 use Eventjet\Ausdruck\FieldAccess;
 use Eventjet\Ausdruck\Get;
 use Eventjet\Ausdruck\ListLiteral;
+use Eventjet\Ausdruck\Precedence;
 use Eventjet\Ausdruck\StructLiteral;
 use Eventjet\Ausdruck\Type;
 
@@ -152,7 +153,7 @@ final class ExpressionParser
      *
      * The loop is what makes this level left-associative: each operator folds what came before into its left operand.
      * {@see self::parseComparison()} is otherwise the same shape with an if in place of the loop, which is what makes
-     * the six comparison operators non-associative; {@see \Eventjet\Ausdruck\Precedence::leftSlot()} reads that one
+     * the six comparison operators non-associative; {@see Precedence::leftSlot()} reads that one
      * difference back out when an expression is printed.
      */
     private function parseAdditive(): Expression

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -195,8 +195,12 @@ final class ExpressionParser
     }
 
     /**
-     * -foo:int
-     * ========
+     * -foo:int   !foo:bool
+     * ========   =========
+     *
+     * The only level that reads its operand at its own level rather than at the next one down, which it does by calling
+     * itself: a prefix operator applies to whatever follows it, including another prefix operator, so `!!a:bool` and
+     * `- -1` are expressions rather than syntax errors.
      *
      * Negating a number literal produces a negative literal rather than a negation of a positive one, but that's
      * {@see Expr::negative()}'s job, not ours: folding it here would mean returning a primary without going through
@@ -204,13 +208,21 @@ final class ExpressionParser
      */
     private function parseUnary(): Expression
     {
-        $minus = $this->tokens->peek();
-        if ($minus === null || $minus->token !== Token::Minus) {
+        $operator = $this->tokens->peek();
+        if ($operator === null) {
+            return $this->parsePostfix();
+        }
+        $build = match ($operator->token) {
+            Token::Minus => Expr::negative(...),
+            Token::Not => Expr::not(...),
+            default => null,
+        };
+        if ($build === null) {
             return $this->parsePostfix();
         }
         $this->tokens->next();
         $operand = $this->parseUnary();
-        return Expr::negative($operand, $minus->location()->to($operand->location()));
+        return $build($operand, $operator->location()->to($operand->location()));
     }
 
     /**

--- a/src/Parser/Token.php
+++ b/src/Parser/Token.php
@@ -13,6 +13,7 @@ enum Token: string
     case Dot = '.';
     case TripleEquals = '===';
     case NotEquals = '!==';
+    case Not = '!';
     case Quote = '"';
     case OpenParen = '(';
     case CloseParen = ')';

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -30,9 +30,9 @@ final class Tokenizer
      * Every character that begins an operator is listed once, in the match below, and its arm answers which operator it
      * begins: the token itself for a character that is a whole operator on its own, {@see self::pair()} for one that
      * may be completed by a second, {@see self::angle()} for the two that may be and mean something else when they
-     * aren't, {@see self::bang()} for the one whose longer reading is longer than that, and {@see self::exact()} for
-     * one that begins a token and nothing else. Giving `+` a longer reading later means changing what its arm answers,
-     * not moving the arm somewhere a different rule applies.
+     * aren't, {@see self::bang()} for `!`, which is a whole operator on its own and also begins `!==`, and
+     * {@see self::exact()} for one that begins a token and nothing else. Giving `+` a longer reading later means
+     * changing what its arm answers, not moving the arm somewhere a different rule applies.
      *
      * The arms only look ahead; naming the token is all they do. Scanning past it is the loop's job below, and it needs
      * nothing but the answer: every {@see Token}'s value is the source text that spells it, so the operator is as many

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -30,8 +30,9 @@ final class Tokenizer
      * Every character that begins an operator is listed once, in the match below, and its arm answers which operator it
      * begins: the token itself for a character that is a whole operator on its own, {@see self::pair()} for one that
      * may be completed by a second, {@see self::angle()} for the two that may be and mean something else when they
-     * aren't, and {@see self::exact()} for one that begins a token and nothing else. Giving `+` a longer reading later
-     * means changing what its arm answers, not moving the arm somewhere a different rule applies.
+     * aren't, {@see self::bang()} for the one whose longer reading is longer than that, and {@see self::exact()} for
+     * one that begins a token and nothing else. Giving `+` a longer reading later means changing what its arm answers,
+     * not moving the arm somewhere a different rule applies.
      *
      * The arms only look ahead; naming the token is all they do. Scanning past it is the loop's job below, and it needs
      * nothing but the answer: every {@see Token}'s value is the source text that spells it, so the operator is as many
@@ -71,7 +72,7 @@ final class Tokenizer
                 '{' => Token::OpenBrace,
                 '}' => Token::CloseBrace,
                 '=' => self::exact($chars, $line, $column, Token::TripleEquals),
-                '!' => self::exact($chars, $line, $column, Token::NotEquals),
+                '!' => self::bang($chars, $line, $column),
                 '&' => self::exact($chars, $line, $column, Token::And),
                 '<' => self::angle($chars, Token::OpenAngle, Token::LessThanEquals),
                 '>' => self::angle($chars, Token::CloseAngle, Token::GreaterThanEquals),
@@ -152,11 +153,12 @@ final class Tokenizer
     }
 
     /**
-     * Answers the operator that is the only token starting with its first character: `===`, `!==`, and `&&`. Once that
-     * first character is there, the whole sequence is required; anything short of it is an error naming the operator
-     * that was expected and underlining the characters that were actually read. The sequence is the token's own
-     * spelling, so the operator the error names is the one it was scanning for, and $ahead—how far into that spelling
-     * the reading got—is at once how far to peek, how much was read, and where the underline ends.
+     * Answers the operator that is the only token the reading can still be: `===` and `&&` from their first character,
+     * `!==` from the `!=` that {@see self::bang()} has committed to. Once that much is there, the whole sequence is
+     * required; anything short of it is an error naming the operator that was expected and underlining the characters
+     * that were actually read. The sequence is the token's own spelling, so the operator the error names is the one it
+     * was scanning for, and $ahead—how far into that spelling the reading got—is at once how far to peek, how much was
+     * read, and where the underline ends.
      *
      * @param Peekable<string> $chars
      * @param positive-int $line
@@ -194,6 +196,21 @@ final class Tokenizer
         return $chars->peek(1) === '=' && $chars->peek(2) === '='
             ? $bare
             : self::pair($chars, '=', $bare, $pair);
+    }
+
+    /**
+     * `!` is the negation operator on its own and the start of the inequality `!==`—{@see self::pair()}'s choice, with
+     * a partner too long for one character of lookahead to settle. A single `=` after the bang is enough to commit to
+     * it, because nothing that can follow a negation starts with one, and {@see self::exact()} then requires the rest.
+     * That is what keeps `a != b` reported as the `!==` it was reaching for, rather than as a negation of a stray `=`.
+     *
+     * @param Peekable<string> $chars
+     * @param positive-int $line
+     * @param positive-int $column
+     */
+    private static function bang(Peekable $chars, int $line, int $column): Token
+    {
+        return $chars->peek(1) === '=' ? self::exact($chars, $line, $column, Token::NotEquals) : Token::Not;
     }
 
     /**

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -54,15 +54,6 @@ enum Precedence: int
     case Primary = 7;
 
     /**
-     * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
-     * it binds looser than $slot and would otherwise be re-parsed into a different tree.
-     */
-    public static function parenthesize(Expression $operand, self $slot): string
-    {
-        return self::of($operand)->bindsLooserThan($slot) ? sprintf('(%s)', $operand) : (string)$operand;
-    }
-
-    /**
      * Prints a binary operator node. Its level comes from {@see self::of()}, and both operand slots follow from the
      * level alone: the right slot is one level tighter, because every level of the cascade reads its right operand by
      * calling the next one down, and the left slot is the level's {@see self::leftSlot()}. `a:int - (b:int - c:int)`
@@ -82,6 +73,16 @@ enum Precedence: int
     }
 
     /**
+     * Prints a unary operator node. Its operand sits at {@see self::Unary}, the level itself rather than the tighter
+     * one a binary operator's right slot gets: {@see ExpressionParser::parseUnary()} reads its operand by calling
+     * itself, so a unary operator's operand may be another one—`!!a:bool`, `- -a:int`—with nothing between them.
+     */
+    public static function unary(UnaryOperator $operator): string
+    {
+        return sprintf('%s%s', $operator->symbol(), self::parenthesize($operator->expression, self::Unary));
+    }
+
+    /**
      * Prints $target as it appears before a postfix `.`—the receiver of a call or field access. This is the
      * {@see self::Primary} slot, so precedence alone would never wrap anything; a bare number literal is the one
      * exception, and needs parentheses for a reason the precedence cascade doesn't model. `2.abs:int()` re-tokenizes
@@ -98,12 +99,22 @@ enum Precedence: int
     }
 
     /**
+     * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
+     * it binds looser than $slot and would otherwise be re-parsed into a different tree.
+     */
+    private static function parenthesize(Expression $operand, self $slot): string
+    {
+        return self::of($operand)->bindsLooserThan($slot) ? sprintf('(%s)', $operand) : (string)$operand;
+    }
+
+    /**
      * Only the nodes that bind loosely enough to ever need wrapping are named; everything else is primary-tight. The
      * default is deliberately forgiving rather than a hard error: {@see Expression} is public API, so a consumer can
      * add nodes this enum has never heard of, and an unknown node is almost always atomic—the safe reading is to
      * treat it as {@see self::Primary} rather than reject it. It is never reached by an operator of this library's
      * own, though: a {@see BinaryOperator} carries the token it is spelled with, which fixes its level in
-     * {@see self::ofToken()}, so one can't be added without being placed in the cascade. (A number literal is the one
+     * {@see self::ofToken()}, and a {@see UnaryOperator} is named by its base class, the cascade having a single level
+     * for all of them, so neither can be added without being placed in the cascade. (A number literal is the one
      * primary-tight node that still needs wrapping in a slot; that's a lexical quirk of the postfix `.`, handled in
      * {@see self::parenthesizeTarget()} rather than by a level of its own.)
      */
@@ -112,7 +123,7 @@ enum Precedence: int
         return match (true) {
             $expr instanceof BinaryOperator => self::ofToken($expr->token()),
             $expr instanceof Lambda => self::Lambda,
-            $expr instanceof Negative => self::Unary,
+            $expr instanceof UnaryOperator => self::Unary,
             default => self::Primary,
         };
     }

--- a/src/UnaryOperator.php
+++ b/src/UnaryOperator.php
@@ -60,9 +60,11 @@ abstract class UnaryOperator extends Expression
     }
 
     /**
-     * The token the parser reads this operator as, which is what gives the operator its spelling. Unlike a binary
-     * operator's, it doesn't fix a precedence level: the cascade has a single unary level, and everything spelled at it
-     * binds equally tight.
+     * The token the parser reads this operator as, which is what gives the operator its spelling. Protected, unlike
+     * {@see BinaryOperator::token()}, because nothing outside the hierarchy has anything to ask it: a binary operator's
+     * token fixes its precedence level, so {@see Precedence} reads it, while the cascade has a single unary level and
+     * everything spelled at it binds equally tight—{@see self::symbol()} is the only caller. That also keeps the
+     * internal {@see Token} off the public surface of {@see Negative}, which is not itself internal.
      */
-    abstract public function token(): Token;
+    abstract protected function token(): Token;
 }

--- a/src/UnaryOperator.php
+++ b/src/UnaryOperator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+/**
+ * An operator with one operand sub-expression and a prefix spelling. It is {@see BinaryOperator}'s counterpart, and
+ * holds the same things for the same reason: two such operators differ only in the token they are spelled with, how
+ * they evaluate, and the type they give the result, and printing follows from the token alone, so a subclass has no way
+ * to print itself in a way the parser would read back differently.
+ *
+ * The one thing a unary operator has to carry that a binary one doesn't is its location: the operator stands to the
+ * left of its only operand, so where it begins isn't anywhere in the tree below it.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+abstract class UnaryOperator extends Expression
+{
+    use LocationTrait;
+
+    public function __construct(public readonly Expression $expression, Span $location)
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * Not final, unlike {@see BinaryOperator::__toString()}, and neither is {@see self::equals()}: {@see Negative}
+     * published both before there was a base class to move them to, and marking them final now would be a backward
+     * compatibility break. It costs nothing to leave them open—every operator here is a final class, so there is
+     * nothing that could override them.
+     */
+    public function __toString(): string
+    {
+        return Precedence::unary($this);
+    }
+
+    /**
+     * How the operator is spelled in the language, e.g. `!`. Taken from the token the parser reads it as, so the
+     * printer can't spell an operator differently than the lexer reads it.
+     */
+    final public function symbol(): string
+    {
+        return $this->token()->value;
+    }
+
+    /**
+     * Two operator nodes are the same expression when they are the same operator over an equal operand.
+     */
+    #[Override]
+    public function equals(Expression $other): bool
+    {
+        return $other instanceof static
+            && $this->expression->equals($other->expression);
+    }
+
+    /**
+     * The token the parser reads this operator as, which is what gives the operator its spelling. Unlike a binary
+     * operator's, it doesn't fix a precedence level: the cascade has a single unary level, and everything spelled at it
+     * binds equally tight.
+     */
+    abstract public function token(): Token;
+}

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -19,6 +19,7 @@ use Eventjet\Ausdruck\Literal;
 use Eventjet\Ausdruck\Modulo;
 use Eventjet\Ausdruck\Multiply;
 use Eventjet\Ausdruck\Negative;
+use Eventjet\Ausdruck\Not;
 use Eventjet\Ausdruck\Or_;
 use Eventjet\Ausdruck\Parser\Span;
 use Eventjet\Ausdruck\StructLiteral;
@@ -98,6 +99,10 @@ final class ExpressionComparisonTest extends TestCase
         yield [
             Expr::negative(Expr::literal(1)),
             Expr::literal(-1),
+        ];
+        yield [
+            Expr::not(Expr::get('a', Type::bool())),
+            Expr::not(Expr::get('a', Type::bool())),
         ];
         yield [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),
@@ -370,6 +375,14 @@ final class ExpressionComparisonTest extends TestCase
         yield Negative::class . ': different expression' => [
             Expr::negative(Expr::get('a', Type::int())),
             Expr::negative(Expr::get('b', Type::int())),
+        ];
+        yield Not::class . ': different type' => [
+            Expr::not(Expr::literal(true)),
+            Expr::literal(true),
+        ];
+        yield Not::class . ': different expression' => [
+            Expr::not(Expr::literal(true)),
+            Expr::not(Expr::literal(false)),
         ];
         yield ListLiteral::class . ': different elements' => [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),

--- a/tests/unit/Parser/ExpressionParserErrorTest.php
+++ b/tests/unit/Parser/ExpressionParserErrorTest.php
@@ -84,11 +84,13 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'missing right hand side of >=' => ['foo:int >='];
         yield 'missing right hand side of <=' => ['foo:int <='];
         yield 'missing right hand side of !==' => ['foo:int !=='];
-        // Equality is `===`, so inequality is `!==`; a bare `!` or `!=` is read as the beginning of one, and the
-        // error says how far it got.
+        yield 'missing operand of !' => ['!', 'Expected expression, got end of input'];
+        // Equality is `===`, so inequality is `!==`; one `=` after a bang is therefore the beginning of one, and the
+        // error says how far it got. A bang with no `=` after it is the negation operator, which is simply in the
+        // wrong place here — there is nothing for it to negate to the right, and nothing joining it to the left.
         yield 'not equals with one equals' => ['a:int != 1', 'Expected !==, got !='];
-        yield 'lone bang' => ['a:int ! 1', 'Expected !==, got !'];
-        yield 'bang at end of input' => ['a:int !', 'Expected !==, got !'];
+        yield 'lone bang' => ['a:int ! 1', 'Unexpected !'];
+        yield 'bang at end of input' => ['a:int !', 'Unexpected !'];
         // Two `=` after a `>` keep the angle bare, whatever comes next (see the `foo:list<int>===bar` parse case), so
         // the `==` here is blamed as its own broken `===` rather than a `>=` eating its first `=`.
         yield 'greater-equals with an extra equals' => ['a:int >== 1', 'Expected ===, got =='];
@@ -163,6 +165,14 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'and with string on the right' => [
             'foo:bool && bar:string',
             'The expression on the right side of && must be boolean, got string',
+        ];
+        // `!` follows the same rule with only one operand to point at, so it names no side.
+        yield 'not with a string operand' => ['!foo:string', 'The operand of ! must be boolean, got string'];
+        yield 'not with an int operand' => ['!foo:int', 'The operand of ! must be boolean, got int'];
+        // An Option of a bool is not a bool, so a `/` under a `!` needs its unwrap like it does anywhere else.
+        yield 'not of a quotient' => [
+            '!(a:int / b:int)',
+            'The operand of ! must be boolean, got Option<int>',
         ];
         yield 'equals: different operand types' => ['foo:string === bar:int'];
         yield 'subtract int from float' => ['foo:float - bar:int', 'Can\'t subtract int from float'];
@@ -419,12 +429,13 @@ final class ExpressionParserErrorTest extends TestCase
                 'foo:bool & bar:bool',
                 '         =         ',
             ],
-            // A `!` or `=` that isn't the start of `!==`/`===` is blamed with everything read after it: the operator
+            // A `!=` or `=` that isn't the start of `!==`/`===` is blamed with everything read after it: the operator
             // that is actually there is underlined whole.
             [
                 'a:int != 1',
                 '      ==  ',
             ],
+            // A bare `!` is a token of its own, so what's wrong with it isn't how far it was read but where it sits.
             [
                 'a:int ! 1',
                 '      =  ',
@@ -540,6 +551,12 @@ final class ExpressionParserErrorTest extends TestCase
             [
                 'a:bool && b:int || c:bool',
                 '          =====          ',
+            ],
+            // The operand of a `!` is blamed on its own, without the operator: the mistake is the expression that
+            // isn't a bool, and the `!` in front of it is the only thing that's right about it.
+            [
+                '!a:int',
+                ' =====',
             ],
             [
                 'a:bool || b:bool && c:int',

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -210,6 +210,43 @@ final class ExpressionParserTest extends TestCase
                 'a:int * -b:int',
                 Expr::multiply(Expr::get('a', $i), Expr::negative(Expr::get('b', $i))),
             ],
+            // `!` sits at the same level as unary `-`, so it binds tighter than every binary operator its operand
+            // could be part of: this negates a, not the conjunction, and not the comparison below.
+            ['!a:bool', Expr::get('a', $b)->not()],
+            // A negated number literal is a literal, but a negated boolean one isn't: nothing is folded here, because
+            // `false` isn't another spelling of `!true`, it's a different expression that evaluates the same.
+            ['!true', Expr::not(Expr::literal(true))],
+            [
+                '!a:bool && b:bool',
+                Expr::and_(Expr::get('a', $b)->not(), Expr::get('b', $b)),
+            ],
+            [
+                '!a:bool === b:bool',
+                Expr::eq(Expr::get('a', $b)->not(), Expr::get('b', $b)),
+            ],
+            // A unary operator reads its operand at its own level, so another one may follow it bare.
+            ['!!a:bool', Expr::get('a', $b)->not()->not()],
+            // ...and anything looser has to be wrapped to stay the operand: without the parentheses the `!` would
+            // take only a, and the rest of the expression would be built around the negation instead of under it.
+            [
+                '!(a:bool || b:bool)',
+                Expr::not(Expr::or_(Expr::get('a', $b), Expr::get('b', $b))),
+            ],
+            [
+                '!(a:int > b:int)',
+                Expr::not(Expr::gt(Expr::get('a', $i), Expr::get('b', $i))),
+            ],
+            // Postfix binds tighter still, so a bare `!` in front of a call negates what the call returns. That is the
+            // composition `x === false` couldn't express: a call is not allowed in every operand slot of a comparison.
+            [
+                '!xs:list<bool>.contains:bool(true)',
+                Expr::not(Expr::get('xs', Type::listOf($b))->call('contains', $b, [Expr::literal(true)])),
+            ],
+            // ...which is also why calling a method on a negation needs the parentheses, exactly as it does for `-`.
+            [
+                '(!a:bool).foo:bool()',
+                Expr::get('a', $b)->not()->call('foo', $b, []),
+            ],
             // Operators are allowed wherever an expression is expected, not just at the top level.
             [
                 '[1 - 2]',
@@ -431,6 +468,9 @@ final class ExpressionParserTest extends TestCase
             // Negating a number literal folds into a negative literal, so the fold survives being nested.
             ['[-2]', Expr::listLiteral([Expr::literal(-2)], Span::char(1, 1))],
             ['- -1', Expr::literal(1)],
+            // Parentheses around the operand of a `!` are as redundant as any other pair the precedence would have
+            // produced anyway: the unary level reads its operand at its own level, so the group changes nothing.
+            ['!(!a:bool)', Expr::get('a', Type::bool())->not()->not()],
             // Parentheses that only restate the default grouping leave no trace: the tree is the one the operators
             // would have built anyway, so it prints back without them. A single atom in parentheses is the same atom.
             ['(a:bool)', Expr::get('a', Type::bool())],

--- a/tests/unit/cases/not/binds-tighter-than-and.txt
+++ b/tests/unit/cases/not/binds-tighter-than-and.txt
@@ -1,0 +1,5 @@
+!a:bool && b:bool
+-- Input --
+{ a: true, b: false }
+-- Output --
+false

--- a/tests/unit/cases/not/call-result.txt
+++ b/tests/unit/cases/not/call-result.txt
@@ -1,0 +1,5 @@
+!haystack:list<string>.contains:bool(needle:string)
+-- Input --
+{ haystack: ["foo", "bar"], needle: "baz" }
+-- Output --
+true

--- a/tests/unit/cases/not/double-negation.txt
+++ b/tests/unit/cases/not/double-negation.txt
@@ -1,0 +1,5 @@
+!!a:bool
+-- Input --
+{ a: true }
+-- Output --
+true

--- a/tests/unit/cases/not/false-is-true.txt
+++ b/tests/unit/cases/not/false-is-true.txt
@@ -1,0 +1,5 @@
+!a:bool
+-- Input --
+{ a: false }
+-- Output --
+true

--- a/tests/unit/cases/not/groups-or.txt
+++ b/tests/unit/cases/not/groups-or.txt
@@ -1,0 +1,5 @@
+!(a:bool || b:bool)
+-- Input --
+{ a: false, b: false }
+-- Output --
+true

--- a/tests/unit/cases/not/true-is-false.txt
+++ b/tests/unit/cases/not/true-is-false.txt
@@ -1,0 +1,5 @@
+!a:bool
+-- Input --
+{ a: true }
+-- Output --
+false


### PR DESCRIPTION
Closes #50.

`!` negates a bool, at the unary level unary `-` already occupies:

```
!a:bool
!!a:bool
!(a:bool || b:bool)
!names:list<string>.contains:bool(needle:string)
```

It binds tighter than every binary operator and looser than the postfix dot, so `!a:bool && b:bool` is
`(!a:bool) && b:bool`, and a call is negated whole — which is the composition `x === false` couldn't express, since a
call can't sit on the left of a comparison in every position.

### The unary level gets a base class

Two unary operators are one more than `Precedence` could keep honest by naming concrete classes, so `Negative` and
`Not` share a `UnaryOperator` base that mirrors `BinaryOperator`: it carries the operand, the location the operator
starts at, and the token that fixes its spelling, and it prints through `Precedence`, so a subclass can't spell itself
differently than the lexer reads it. `Precedence::of()` names the base class instead of `Negative`, and
`parenthesize()` lost its last caller outside `Precedence`, so it's private now.

### `!` in the tokenizer

`!` no longer commits to `!==` on sight. One `=` after the bang still does — nothing that can follow a negation starts
with one — so `a:int != 1` is still reported as the `!==` it was reaching for. A bang with no `=` after it is the
negation operator, so a misplaced one is now an unexpected `!` rather than an unfinished `!==`:

| Input | Before | After |
|-------|--------|-------|
| `a:int != 1` | `Expected !==, got !=` | unchanged |
| `a:int ! 1` | `Expected !==, got !` | `Unexpected !` |
| `a:int !` | `Expected !==, got !` | `Unexpected !` |

### Type errors

The operand rule is the one `&&` and `||` follow, with the single operand `!` has to point at: `!foo:int` is
`The operand of ! must be boolean, got int`, underlining the operand alone. The shared check in `Expr` now takes how
the operand is named rather than an operator and a side; the `&&`/`||` messages are unchanged.

Nothing is folded, unlike a negated number literal: `!true` stays a negation of the literal `true`, because `false` is
a different expression that happens to evaluate the same.

### Checks

All green. One note on the BC check: `__toString()` and `equals()` are *not* final on `UnaryOperator`, unlike their
`BinaryOperator` counterparts. `Negative` published both non-final before there was a base class to move them to, and
Roave reports finalizing them as a break. It costs nothing to leave them open — every operator here is a final class,
so nothing can override them — and the class comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hPJFKAuT6KvwTfBMMagQ4
