### PR TITLE
Lift Negative onto a UnaryOperator base class

### DIFF
--- a/src/Negative.php
+++ b/src/Negative.php
@@ -4,28 +4,14 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
-use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Override;
-
-use function sprintf;
 
 /**
  * Never wraps a {@see Literal}: {@see Expr::negative()} folds a negated number literal into a negative one.
  */
-final class Negative extends Expression
+final class Negative extends UnaryOperator
 {
-    use LocationTrait;
-
-    public function __construct(public readonly Expression $expression, Span $location)
-    {
-        $this->location = $location;
-    }
-
-    public function __toString(): string
-    {
-        return sprintf('-%s', Precedence::parenthesize($this->expression, Precedence::Unary));
-    }
-
     /**
      * Negation is arithmetic too, and follows the rule {@see Arithmetic} sets: the operand is narrowed to the type it
      * claims, and an int result that doesn't exist is reported rather than widened. Which int result that is, and why,
@@ -42,15 +28,17 @@ final class Negative extends Expression
     }
 
     #[Override]
-    public function equals(Expression $other): bool
-    {
-        return $other instanceof self
-            && $this->expression->equals($other->expression);
-    }
-
-    #[Override]
     public function getType(): Type
     {
         return $this->expression->getType();
+    }
+
+    /**
+     * @return Token::Minus
+     */
+    #[Override]
+    protected function token(): Token
+    {
+        return Token::Minus;
     }
 }

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -26,7 +26,7 @@ use function sprintf;
  * have grouped that way anyway — are dropped.
  *
  * A binary operator's level comes from the token it is spelled with, so an operator can't exist without one. That token
- * is also what the printer here spells the operator with, which makes this the only place in the library where an
+ * is also what both printers here spell the operator with, which makes this the only place in the library where an
  * operator node is spelled back into an expression: an operator can only be printed the way the lexer reads it back.
  *
  * Grouping, on the other hand, is not stored anywhere: parentheses leave no trace in the tree, so the same tree always
@@ -57,23 +57,15 @@ enum Precedence: int
     case Primary = 7;
 
     /**
-     * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
-     * it binds looser than $slot and would otherwise be re-parsed into a different tree.
-     */
-    public static function parenthesize(Expression $operand, self $slot): string
-    {
-        return self::of($operand)->bindsLooserThan($slot) ? sprintf('(%s)', $operand) : (string)$operand;
-    }
-
-    /**
      * Prints a binary operator from the token it is spelled with and its two operands. Its level comes from
      * {@see self::ofToken()}, and both operand slots follow from the level alone: the right slot is one level
      * tighter, because every level of the cascade reads its right operand by calling the next one down, and the left
      * slot is the level's {@see self::leftSlot()}. `a:int - (b:int - c:int)` keeps its parentheses because the right
      * slot is the tighter one; `(a:int - b:int) - c:int` loses them because the additive left slot isn't;
      * `(a:int === b:int) === c:bool` keeps them on either side because the comparison level's left slot is tighter
-     * too. It is a {@see Token} rather than a string because a spelling the lexer has no token for is not something a
-     * caller may ask for, and taking the token is what makes that unsayable.
+     * too. It is a {@see Token} rather than a string for the same reason {@see self::unary()} takes one: a spelling
+     * the lexer has no token for is not something a caller may ask for, and taking the token is what makes that
+     * unsayable.
      */
     public static function binary(Token $token, Expression $left, Expression $right): string
     {
@@ -84,6 +76,20 @@ enum Precedence: int
             $token->value,
             self::parenthesize($right, $level->tighter()),
         );
+    }
+
+    /**
+     * Prints a unary operator from the token it is spelled with and its operand, the same family as
+     * {@see self::binary()}: neither printer picks anything by hand beyond looking the token's level up. The operand
+     * sits at {@see self::Unary}, the level itself rather than the tighter one a binary operator's right slot gets:
+     * {@see ExpressionParser::parseUnary()} reads its operand by calling itself, so a unary operator's operand may be
+     * another one—`--a:int`—with nothing between them.
+     *
+     * @param Token::Minus $token
+     */
+    public static function unary(Token $token, Expression $operand): string
+    {
+        return sprintf('%s%s', $token->value, self::parenthesize($operand, self::Unary));
     }
 
     /**
@@ -103,12 +109,22 @@ enum Precedence: int
     }
 
     /**
+     * Prints $operand as it appears in an operand slot that the parser reads at $slot, wrapping it in parentheses when
+     * it binds looser than $slot and would otherwise be re-parsed into a different tree.
+     */
+    private static function parenthesize(Expression $operand, self $slot): string
+    {
+        return self::of($operand)->bindsLooserThan($slot) ? sprintf('(%s)', $operand) : (string)$operand;
+    }
+
+    /**
      * Only the nodes that bind loosely enough to ever need wrapping are named; everything else is primary-tight. The
      * default is deliberately forgiving rather than a hard error: {@see Expression} is public API, so a consumer can
      * add nodes this enum has never heard of, and an unknown node is almost always atomic—the safe reading is to
      * treat it as {@see self::Primary} rather than reject it. It is never reached by an operator of this library's
      * own, though: a {@see BinaryOperator} carries the token it is spelled with, which fixes its level in
-     * {@see self::ofToken()}, so one can't be added without being placed in the cascade. (A number literal is the one
+     * {@see self::ofToken()}, and a {@see UnaryOperator} is named by its base class, the cascade having a single level
+     * for all of them, so neither can be added without being placed in the cascade. (A number literal is the one
      * primary-tight node that still needs wrapping in a slot; that's a lexical quirk of the postfix `.`, handled in
      * {@see self::parenthesizeTarget()} rather than by a level of its own.)
      */
@@ -117,7 +133,7 @@ enum Precedence: int
         return match (true) {
             $expr instanceof BinaryOperator => self::ofToken($expr->token()),
             $expr instanceof Lambda => self::Lambda,
-            $expr instanceof Negative => self::Unary,
+            $expr instanceof UnaryOperator => self::Unary,
             default => self::Primary,
         };
     }

--- a/src/UnaryOperator.php
+++ b/src/UnaryOperator.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+/**
+ * An operator with one operand sub-expression and a prefix spelling. It is {@see BinaryOperator}'s counterpart, and
+ * holds the same things for the same reason: two such operators differ only in the token they are spelled with, how
+ * they evaluate, and the type they give the result, and printing follows from the token alone, so a subclass has no way
+ * to print itself in a way the parser would read back differently.
+ *
+ * The one thing a unary operator has to carry that a binary one doesn't is its location: the operator stands to the
+ * left of its only operand, so the node's span can't be derived from its subtree the way a binary operator's is.
+ *
+ * Unlike {@see BinaryOperator}, this class carries no `@internal`: {@see Negative} published it by omission, before
+ * there was a base class to lift it into, so every member declared here—inherited by `Negative` and any other
+ * subclass—is public API of a published class. Psalm resolves internality from the declaring class, not the
+ * subclass, so annotating the base would silently take that API away without either tool or docblock saying so.
+ * That is a real constraint on what may live here, not a fact to note in passing:
+ *
+ * - The operand lives in a property called $expression, though every docblock here calls it the operand: `Negative`
+ *   published that name first, so it is fixed.
+ * - {@see self::__toString()} and {@see self::equals()} are not `final`, unlike their {@see BinaryOperator}
+ *   counterparts: `Negative` published both before there was a base class to move them to, and neither can become
+ *   final without risking a consumer's override.
+ * - {@see self::token()} is `protected`, unlike the public {@see BinaryOperator::token()}: `Negative` never
+ *   published it, so nothing forces it public, and {@see Precedence::unary()} takes the token and the operand
+ *   instead of the node for exactly that reason. Being public would not have opened the hierarchy to outside
+ *   subclasses anyway: {@see self::token()} returns {@see Token}, which is itself `@internal`, so nothing outside
+ *   this namespace can implement the abstract method regardless of its visibility.
+ *
+ * Marking the hierarchy `@internal`, which would let all three become the {@see BinaryOperator} shape, is a backward
+ * compatibility break and waits for the next major; tracked as eventjet/ausdruck#83.
+ */
+abstract class UnaryOperator extends Expression
+{
+    use LocationTrait;
+
+    public function __construct(public readonly Expression $expression, Span $location)
+    {
+        $this->location = $location;
+    }
+
+    public function __toString(): string
+    {
+        return Precedence::unary($this->token(), $this->expression);
+    }
+
+    /**
+     * Two operator nodes are the same expression when they are the same operator over an equal operand.
+     */
+    #[Override]
+    public function equals(Expression $other): bool
+    {
+        return $other instanceof static
+            && $this->expression->equals($other->expression);
+    }
+
+    /**
+     * The token the parser reads this operator as, which is what gives the operator its spelling.
+     *
+     * @return Token::Minus
+     */
+    abstract protected function token(): Token;
+}


### PR DESCRIPTION
Split from #82.

`Negative` held its operand, its location, its printing and its equality itself, all of which are facts about prefix operators rather than about negation. `BinaryOperator` already draws that line for infix operators; this is its counterpart, and what is left in `Negative` is what actually differs between one prefix operator and another: the token it is spelled with, how it evaluates, and the type it gives the result.

Printing follows the token, the way it now does for binary operators: `Precedence::unary()` is the same shape as `Precedence::binary()`, except that its operand sits at the unary level itself rather than one tighter, because `parseUnary()` reads its operand by calling itself. That also makes `Precedence::parenthesize()` private — `Negative` was its last outside caller.

The base class carries no `@internal`, and can't: `Negative` published every member it now inherits, and Psalm resolves internality from the declaring class. What that costs is written down where it binds, along with the issue that undoes it at the next major (#83).

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hPJFKAuT6KvwTfBMMagQ4