### PR TITLE
Add the boolean negation operator !

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [Types](#types)
 
 ### Operators
 
-Both operands must be of the same type.
+Most operators go between two operands of the same type:
 
 | Operator | Description           | Example                  | Note                                            |
 |----------|-----------------------|--------------------------|-------------------------------------------------|
@@ -76,9 +76,24 @@ Both operands must be of the same type.
 | `<`      | Less than             | `foo:int < bar:int`      | Operands must be of type `int` or `float`       |
 | `<=`     | Less than or equal    | `foo:int <= bar:int`     | Operands must be of type `int` or `float`       |
 | `\|\|`   | Logical OR            | `foo:bool \|\| bar:bool` | Operands must be of type `bool`                 |
-| &&       | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`                 |
+| `&&`     | Logical AND           | `foo:bool && bar:bool`   | Operands must be of type `bool`                 |
 
 Equality is spelled `===`, so inequality is `!==`; there is no `==` or `!=`.
+
+Two operators take a single operand, written in front of it:
+
+| Operator | Description | Example     | Note                                         |
+|----------|-------------|-------------|----------------------------------------------|
+| `-`      | Negation    | `-foo:int`  | The operand must be of type `int` or `float` |
+| `!`      | Logical NOT | `!foo:bool` | The operand must be of type `bool`           |
+
+Both prefix operators bind tighter than every binary operator, so each applies only to the expression right next to it
+and nothing more: `!foo:bool && bar:bool` is `(!foo:bool) && bar:bool`, and `-foo:int + bar:int` is
+`(-foo:int) + bar:int`. That includes calls and field access, which bind tighter still, so a call is negated whole:
+
+```
+!names:list<string>.contains:bool(needle:string)
+```
 
 Where's the rest? We're implementing more as we need them.
 
@@ -128,7 +143,7 @@ Operators bind from tightest to loosest in this order:
 | Operator                           | Associativity   |
 |------------------------------------|-----------------|
 | `.` (field, method)                | Left            |
-| `-` (negation)                     | Right           |
+| `-` (negation), `!`                | Right           |
 | `*`, `/`, `%`                      | Left            |
 | `-` (subtraction), `+`             | Left            |
 | `===`, `!==`, `>`, `>=`, `<`, `<=` | Non-associative |
@@ -153,6 +168,7 @@ a:bool && (b:bool || c:bool)
 (a:int + b:int) * c:int
 (a:int > b:int) === c:bool
 (a:int / b:int).unwrap:int()
+!(a:bool || b:bool)
 ```
 
 Parentheses only group; they add no node of their own. Redundant ones — a group the precedence would have produced

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Eventjet\Ausdruck;
 
 use Eventjet\Ausdruck\Parser\Span;
+use Eventjet\Ausdruck\Parser\Token;
 use Eventjet\Ausdruck\Parser\TypeAnnotation;
 use Eventjet\Ausdruck\Parser\TypeError;
 use Eventjet\Ausdruck\Parser\TypeHint;
@@ -110,12 +111,25 @@ final class Expr
 
     public static function or_(Expression $left, Expression $right): Or_
     {
-        return new Or_(self::assertBoolean($left, '||', 'left'), self::assertBoolean($right, '||', 'right'));
+        self::assertBooleanOperands($left, $right, Token::Or);
+        return new Or_($left, $right);
     }
 
     public static function and_(Expression $left, Expression $right): And_
     {
-        return new And_(self::assertBoolean($left, '&&', 'left'), self::assertBoolean($right, '&&', 'right'));
+        self::assertBooleanOperands($left, $right, Token::And);
+        return new And_($left, $right);
+    }
+
+    /**
+     * Nothing is folded here, unlike in {@see self::negative()}: `!true` stays a negation of the literal `true`. The
+     * language spells negative numbers, so a negated number literal has a literal to fold into; it spells no negative
+     * booleans, and `false` is not another spelling of `!true` but a different expression that evaluates the same.
+     */
+    public static function not(Expression $expression, Span|null $location = null): Not
+    {
+        self::assertBooleanOperand($expression, Token::Not);
+        return new Not($expression, $location ?? self::dummySpan());
     }
 
     /**
@@ -441,20 +455,40 @@ final class Expr
     }
 
     /**
-     * @param 'left' | 'right' $side
+     * The rule both binary logical operators (`&&`, `||`) follow. They name their operands the same way, so they share
+     * one wording, and can't drift into blaming the two sides of the same mistake differently. The left side is
+     * checked first, so an expression with both operands bad is blamed on its leftmost one; that is the other half of
+     * not drifting, and is pinned by a test with two bad operands.
      */
-    private static function assertBoolean(Expression $expr, string $operator, string $side): Expression
+    private static function assertBooleanOperands(Expression $left, Expression $right, Token $operator): void
+    {
+        self::assertBoolean($left, sprintf('The expression on the left side of %s', $operator->value));
+        self::assertBoolean($right, sprintf('The expression on the right side of %s', $operator->value));
+    }
+
+    /**
+     * The rule the one unary logical operator, `!`, follows: unlike `&&` and `||` it has a single operand, so there is
+     * no side to name.
+     */
+    private static function assertBooleanOperand(Expression $expr, Token $operator): void
+    {
+        self::assertBoolean($expr, sprintf('The operand of %s', $operator->value));
+    }
+
+    /**
+     * The rule the logical operators share: an operand of `&&`, `||` or `!` has to be boolean. Only how the offending
+     * operand is named differs between them—`!` has a single one, so it names no side—which is what $subject says.
+     *
+     * @param string $subject How the operand is named in the error, e.g. `The operand of !`. It opens the sentence,
+     *     so it has to read as a noun phrase in front of ` must be boolean, got <type>`.
+     */
+    private static function assertBoolean(Expression $expr, string $subject): void
     {
         if ($expr->matchesType(Type::bool())) {
-            return $expr;
+            return;
         }
         throw TypeError::create(
-            sprintf(
-                'The expression on the %s side of %s must be boolean, got %s',
-                $side,
-                $operator,
-                $expr->getType(),
-            ),
+            sprintf('%s must be boolean, got %s', $subject, $expr->getType()),
             $expr->location(),
         );
     }

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -85,6 +85,16 @@ abstract class Expression implements Stringable
     }
 
     /**
+     * Returns self rather than the concrete {@see Not}: Not is internal, so this method, being @api, can't name it as
+     * its return type. Returning self is the shape every builder here is headed for, not a rule this one is the
+     * exception to.
+     */
+    public function not(): self
+    {
+        return Expr::not($this);
+    }
+
+    /**
      * Unlike the other builders, this one can't check its operands: there are no declarations here to look the
      * function's signature up in, so there is nothing to check the receiver and the arguments against. The call is
      * checked against $type when it's evaluated. Parse the expression instead of building it if you want the

--- a/src/Not.php
+++ b/src/Not.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck;
+
+use Eventjet\Ausdruck\Parser\Token;
+use Override;
+
+/**
+ * Boolean negation. Unlike {@see Negative}, it wraps a {@see Literal} like anything else: there is no negative boolean
+ * literal for {@see Expr::not()} to fold one into.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
+final class Not extends UnaryOperator
+{
+    #[Override]
+    public function evaluate(Scope $scope): bool
+    {
+        return !Operand::bool($this->expression->evaluate($scope));
+    }
+
+    /**
+     * Always bool, whatever the operand claims to be: this states `!`'s own contract, the way {@see Or_},
+     * {@see And_} and {@see Comparison} do, rather than leaning on an invariant that {@see Expr::not()} enforces in
+     * another file.
+     */
+    #[Override]
+    public function getType(): Type
+    {
+        return Type::bool();
+    }
+
+    /**
+     * @return Token::Not
+     */
+    #[Override]
+    protected function token(): Token
+    {
+        return Token::Not;
+    }
+}

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -10,6 +10,7 @@ use Eventjet\Ausdruck\Expression;
 use Eventjet\Ausdruck\FieldAccess;
 use Eventjet\Ausdruck\Get;
 use Eventjet\Ausdruck\ListLiteral;
+use Eventjet\Ausdruck\Precedence;
 use Eventjet\Ausdruck\StructLiteral;
 use Eventjet\Ausdruck\Type;
 
@@ -152,8 +153,8 @@ final class ExpressionParser
      *
      * The loop is what makes this level left-associative: each operator folds what came before into its left operand.
      * {@see self::parseComparison()} is otherwise the same shape with an if in place of the loop, which is what makes
-     * the six comparison operators non-associative; {@see \Eventjet\Ausdruck\Precedence::leftSlot()} reads that one
-     * difference back out when an expression is printed.
+     * the six comparison operators non-associative; {@see Precedence::leftSlot()} reads that one difference back out
+     * when an expression is printed.
      */
     private function parseAdditive(): Expression
     {
@@ -195,22 +196,36 @@ final class ExpressionParser
     }
 
     /**
-     * -foo:int
-     * ========
+     * -foo:int   !foo:bool
+     * ========   =========
+     *
+     * The only level that reads its operand at its own level rather than at the next one down, which it does by calling
+     * itself: a prefix operator applies to whatever follows it, including another prefix operator, so `!!a:bool` and
+     * `- -1` are expressions rather than syntax errors.
      *
      * Negating a number literal produces a negative literal rather than a negation of a positive one, but that's
      * {@see Expr::negative()}'s job, not ours: folding it here would mean returning a primary without going through
      * parsePostfix(), and `-2 .abs:int()` would stop parsing.
+     *
+     * It is the only level whose node needs a location of its own: a prefix operator's span starts where the operator
+     * is, which is nowhere in the operand below it. That start is read off {@see self::nextSpan()} before the operator
+     * is consumed—{@see Span::to()} takes only the start from its receiver, so a multi-character operator loses
+     * nothing by being measured at its first character.
      */
     private function parseUnary(): Expression
     {
-        $minus = $this->tokens->peek();
-        if ($minus === null || $minus->token !== Token::Minus) {
+        $build = match ($this->nextToken()) {
+            Token::Minus => Expr::negative(...),
+            Token::Not => Expr::not(...),
+            default => null,
+        };
+        if ($build === null) {
             return $this->parsePostfix();
         }
+        $start = $this->nextSpan();
         $this->tokens->next();
         $operand = $this->parseUnary();
-        return Expr::negative($operand, $minus->location()->to($operand->location()));
+        return $build($operand, $start->to($operand->location()));
     }
 
     /**
@@ -488,6 +503,12 @@ final class ExpressionParser
         return $this->tokens->peek()?->token;
     }
 
+    /**
+     * Where the parser is looking: the next token's own position, or one column past the previous token if there is
+     * no next one. That is where an error about a missing token points—every other caller uses it for exactly that—
+     * and it is also where a prefix operator's span begins, since the operator's own token is where the parser is
+     * looking right before {@see self::parseUnary()} consumes it.
+     */
     private function nextSpan(): Span
     {
         $token = $this->tokens->peek();

--- a/src/Parser/Token.php
+++ b/src/Parser/Token.php
@@ -13,6 +13,7 @@ enum Token: string
     case Dot = '.';
     case TripleEquals = '===';
     case NotEquals = '!==';
+    case Not = '!';
     case Quote = '"';
     case OpenParen = '(';
     case CloseParen = ')';

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -71,7 +71,11 @@ final class Tokenizer
                 '{' => Token::OpenBrace,
                 '}' => Token::CloseBrace,
                 '=' => self::exact($chars, $line, $column, Token::TripleEquals),
-                '!' => self::exact($chars, $line, $column, Token::NotEquals),
+                // `!` on its own is Token::Not; followed by `=` it commits to its pair, `!==`, after the same one
+                // character of lookahead as {@see self::pair()}'s callers below—but that pair is two characters long,
+                // more than a lookahead can settle, so it reads {@see self::exact()} for the rest instead of
+                // returning a token bare.
+                '!' => $chars->peek(1) === '=' ? self::exact($chars, $line, $column, Token::NotEquals) : Token::Not,
                 '&' => self::exact($chars, $line, $column, Token::And),
                 '<' => self::angle($chars, Token::OpenAngle, Token::LessThanEquals),
                 '>' => self::angle($chars, Token::CloseAngle, Token::GreaterThanEquals),
@@ -152,11 +156,12 @@ final class Tokenizer
     }
 
     /**
-     * Answers the operator that is the only token starting with its first character: `===`, `!==`, and `&&`. Once that
-     * first character is there, the whole sequence is required; anything short of it is an error naming the operator
-     * that was expected and underlining the characters that were actually read. The sequence is the token's own
-     * spelling, so the operator the error names is the one it was scanning for, and $ahead—how far into that spelling
-     * the reading got—is at once how far to peek, how much was read, and where the underline ends.
+     * Answers the operator that is the only token the reading can still be: `===` and `&&` from their first character,
+     * `!==` from the peek at its second that the `!` arm has already committed to. Once that much is there, the whole
+     * sequence is required; anything short of it is an error naming the operator that was expected and underlining the
+     * characters that were actually read. The sequence is the token's own spelling, so the operator the error names is
+     * the one it was scanning for, and $ahead—how far into that spelling the reading got—is at once how far to peek,
+     * how much was read, and where the underline ends.
      *
      * @param Peekable<string> $chars
      * @param positive-int $line
@@ -168,7 +173,9 @@ final class Tokenizer
         foreach (str_split($token->value) as $ahead => $char) {
             if ($chars->peek($ahead) !== $char) {
                 $endColumn = $column + $ahead - 1;
-                // The main loop only dispatches here after peeking the token's first character, so that one matched.
+                // Every caller has peeked before dispatching here: the main loop the token's first character, and the
+                // `!` arm its second as well. So the mismatch is never on the first character, and $ahead is at
+                // least 1.
                 assert($endColumn >= 1);
                 throw SyntaxError::create(
                     sprintf('Expected %s, got %s', $token->value, $read),

--- a/src/Precedence.php
+++ b/src/Precedence.php
@@ -83,9 +83,9 @@ enum Precedence: int
      * {@see self::binary()}: neither printer picks anything by hand beyond looking the token's level up. The operand
      * sits at {@see self::Unary}, the level itself rather than the tighter one a binary operator's right slot gets:
      * {@see ExpressionParser::parseUnary()} reads its operand by calling itself, so a unary operator's operand may be
-     * another one—`--a:int`—with nothing between them.
+     * another one—`!!a:bool`, `--a:int`—with nothing between them.
      *
-     * @param Token::Minus $token
+     * @param Token::Minus|Token::Not $token
      */
     public static function unary(Token $token, Expression $operand): string
     {

--- a/src/UnaryOperator.php
+++ b/src/UnaryOperator.php
@@ -64,7 +64,7 @@ abstract class UnaryOperator extends Expression
     /**
      * The token the parser reads this operator as, which is what gives the operator its spelling.
      *
-     * @return Token::Minus
+     * @return Token::Minus|Token::Not
      */
     abstract protected function token(): Token;
 }

--- a/tests/unit/ExpressionComparisonTest.php
+++ b/tests/unit/ExpressionComparisonTest.php
@@ -19,6 +19,7 @@ use Eventjet\Ausdruck\Literal;
 use Eventjet\Ausdruck\Modulo;
 use Eventjet\Ausdruck\Multiply;
 use Eventjet\Ausdruck\Negative;
+use Eventjet\Ausdruck\Not;
 use Eventjet\Ausdruck\Or_;
 use Eventjet\Ausdruck\Parser\Span;
 use Eventjet\Ausdruck\StructLiteral;
@@ -98,6 +99,10 @@ final class ExpressionComparisonTest extends TestCase
         yield [
             Expr::negative(Expr::literal(1)),
             Expr::literal(-1),
+        ];
+        yield [
+            Expr::not(Expr::get('a', Type::bool())),
+            Expr::not(Expr::get('a', Type::bool())),
         ];
         yield [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),
@@ -370,6 +375,14 @@ final class ExpressionComparisonTest extends TestCase
         yield Negative::class . ': different expression' => [
             Expr::negative(Expr::get('a', Type::int())),
             Expr::negative(Expr::get('b', Type::int())),
+        ];
+        yield Not::class . ': different type' => [
+            Expr::not(Expr::literal(true)),
+            Expr::literal(true),
+        ];
+        yield Not::class . ': different expression' => [
+            Expr::not(Expr::literal(true)),
+            Expr::not(Expr::literal(false)),
         ];
         yield ListLiteral::class . ': different elements' => [
             Expr::listLiteral([Expr::literal(1), Expr::literal(2), Expr::literal(3)], Span::char(1, 1)),

--- a/tests/unit/Parser/ExpressionParserErrorTest.php
+++ b/tests/unit/Parser/ExpressionParserErrorTest.php
@@ -84,11 +84,13 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'missing right hand side of >=' => ['foo:int >='];
         yield 'missing right hand side of <=' => ['foo:int <='];
         yield 'missing right hand side of !==' => ['foo:int !=='];
-        // Equality is `===`, so inequality is `!==`; a bare `!` or `!=` is read as the beginning of one, and the
-        // error says how far it got.
+        yield 'missing operand of !' => ['!', 'Expected expression, got end of input'];
+        // Equality is `===`, so inequality is `!==`; one `=` after a bang is therefore the beginning of one, and the
+        // error says how far it got. A bang with no `=` after it is the negation operator, which is simply in the
+        // wrong place here — there is nothing for it to negate to the right, and nothing joining it to the left.
         yield 'not equals with one equals' => ['a:int != 1', 'Expected !==, got !='];
-        yield 'lone bang' => ['a:int ! 1', 'Expected !==, got !'];
-        yield 'bang at end of input' => ['a:int !', 'Expected !==, got !'];
+        yield 'lone bang' => ['a:int ! 1', 'Unexpected !'];
+        yield 'bang at end of input' => ['a:int !', 'Unexpected !'];
         // Two `=` after a `>` keep the angle bare, whatever comes next (see the `foo:list<int>===bar` parse case), so
         // the `==` here is blamed as its own broken `===` rather than a `>=` eating its first `=`.
         yield 'greater-equals with an extra equals' => ['a:int >== 1', 'Expected ===, got =='];
@@ -163,6 +165,20 @@ final class ExpressionParserErrorTest extends TestCase
         yield 'and with string on the right' => [
             'foo:bool && bar:string',
             'The expression on the right side of && must be boolean, got string',
+        ];
+        // Both sides are bad here, so this is the only case that can see which one gets blamed: the left one, because
+        // that's the side checked first. Nothing else pins that order.
+        yield 'and with both operands non-boolean' => [
+            'foo:string && bar:int',
+            'The expression on the left side of && must be boolean, got string',
+        ];
+        // `!` follows the same rule with only one operand to point at, so it names no side.
+        yield 'not with a string operand' => ['!foo:string', 'The operand of ! must be boolean, got string'];
+        yield 'not with an int operand' => ['!foo:int', 'The operand of ! must be boolean, got int'];
+        // An Option of a bool is not a bool, so a `/` under a `!` needs its unwrap like it does anywhere else.
+        yield 'not of a quotient' => [
+            '!(a:int / b:int)',
+            'The operand of ! must be boolean, got Option<int>',
         ];
         yield 'equals: different operand types' => ['foo:string === bar:int'];
         yield 'subtract int from float' => ['foo:float - bar:int', 'Can\'t subtract int from float'];
@@ -419,12 +435,13 @@ final class ExpressionParserErrorTest extends TestCase
                 'foo:bool & bar:bool',
                 '         =         ',
             ],
-            // A `!` or `=` that isn't the start of `!==`/`===` is blamed with everything read after it: the operator
+            // A `!=` or `=` that isn't the start of `!==`/`===` is blamed with everything read after it: the operator
             // that is actually there is underlined whole.
             [
                 'a:int != 1',
                 '      ==  ',
             ],
+            // A bare `!` is a token of its own, so what's wrong with it isn't how far it was read but where it sits.
             [
                 'a:int ! 1',
                 '      =  ',
@@ -541,6 +558,12 @@ final class ExpressionParserErrorTest extends TestCase
                 'a:bool && b:int || c:bool',
                 '          =====          ',
             ],
+            // The operand of a `!` is blamed on its own, without the operator: the mistake is the expression that
+            // isn't a bool, and the `!` in front of it is the only thing that's right about it.
+            [
+                '!a:int',
+                ' =====',
+            ],
             [
                 'a:bool || b:bool && c:int',
                 '                    =====',
@@ -577,9 +600,15 @@ final class ExpressionParserErrorTest extends TestCase
                 'foo:map<bool, string>',
                 '        ====         ',
             ],
+            // A prefix operator's node spans the operator too, so blaming the whole operand underlines both. That is
+            // the span parseUnary() builds, for `-` and `!` alike.
             [
                 'foo:string === -bar:int',
                 '               ========',
+            ],
+            [
+                '1 === !a:bool',
+                '      =======',
             ],
             [
                 'foo:string === bar:list<string>.count:int()',

--- a/tests/unit/Parser/ExpressionParserTest.php
+++ b/tests/unit/Parser/ExpressionParserTest.php
@@ -210,6 +210,48 @@ final class ExpressionParserTest extends TestCase
                 'a:int * -b:int',
                 Expr::multiply(Expr::get('a', $i), Expr::negative(Expr::get('b', $i))),
             ],
+            // A unary operator reads its operand at its own level, so another one may follow it bare, and prints back
+            // out with nothing between them. A number literal folds into a negative literal, so pinning a nested
+            // Negative takes a variable.
+            ['--a:int', Expr::negative(Expr::negative(Expr::get('a', $i)))],
+            // `!` sits at the same level as unary `-`, so it binds tighter than every binary operator its operand
+            // could be part of: this negates a, not the conjunction, and not the comparison below.
+            ['!a:bool', Expr::get('a', $b)->not()],
+            // A negated number literal is a literal, but a negated boolean one isn't: nothing is folded here, because
+            // `false` isn't another spelling of `!true`, it's a different expression that evaluates the same.
+            ['!true', Expr::not(Expr::literal(true))],
+            [
+                '!a:bool && b:bool',
+                Expr::and_(Expr::get('a', $b)->not(), Expr::get('b', $b)),
+            ],
+            [
+                '!a:bool === b:bool',
+                Expr::eq(Expr::get('a', $b)->not(), Expr::get('b', $b)),
+            ],
+            // A unary operator reads its operand at its own level, so another one may follow it bare, here as at `-`.
+            ['!!a:bool', Expr::get('a', $b)->not()->not()],
+            // ...and anything looser has to be wrapped to stay the operand: without the parentheses the `!` would
+            // take only a, and the rest of the expression would be built around the negation instead of under it.
+            [
+                '!(a:bool || b:bool)',
+                Expr::not(Expr::or_(Expr::get('a', $b), Expr::get('b', $b))),
+            ],
+            [
+                '!(a:int > b:int)',
+                Expr::not(Expr::gt(Expr::get('a', $i), Expr::get('b', $i))),
+            ],
+            // Postfix binds tighter still, so a bare `!` in front of a call negates what the call returns. That is the
+            // composition `x === false` couldn't express: comparisons are non-associative, so a negation written that
+            // way can't be fed into another one without parentheses, while `!!x` needs none.
+            [
+                '!xs:list<bool>.contains:bool(true)',
+                Expr::not(Expr::get('xs', Type::listOf($b))->call('contains', $b, [Expr::literal(true)])),
+            ],
+            // ...which is also why calling a method on a negation needs the parentheses, exactly as it does for `-`.
+            [
+                '(!a:bool).foo:bool()',
+                Expr::get('a', $b)->not()->call('foo', $b, []),
+            ],
             // Operators are allowed wherever an expression is expected, not just at the top level.
             [
                 '[1 - 2]',
@@ -431,6 +473,11 @@ final class ExpressionParserTest extends TestCase
             // Negating a number literal folds into a negative literal, so the fold survives being nested.
             ['[-2]', Expr::listLiteral([Expr::literal(-2)], Span::char(1, 1))],
             ['- -1', Expr::literal(1)],
+            // Parentheses around the operand of a prefix operator are as redundant as any other pair the precedence
+            // would have produced anyway: the unary level reads its operand at its own level, so the group changes
+            // nothing.
+            ['!(!a:bool)', Expr::get('a', Type::bool())->not()->not()],
+            ['-(-a:int)', Expr::negative(Expr::negative(Expr::get('a', Type::int())))],
             // Parentheses that only restate the default grouping leave no trace: the tree is the one the operators
             // would have built anyway, so it prints back without them. A single atom in parentheses is the same atom.
             ['(a:bool)', Expr::get('a', Type::bool())],

--- a/tests/unit/Parser/TokenTest.php
+++ b/tests/unit/Parser/TokenTest.php
@@ -16,30 +16,62 @@ final class TokenTest extends TestCase
      */
     public static function printCases(): iterable
     {
-        $tokenCases = [
-            [Token::Dot, '.'],
-            [Token::TripleEquals, '==='],
-            [Token::NotEquals, '!=='],
-            [Token::Quote, '"'],
-            [Token::OpenParen, '('],
-            [Token::CloseParen, ')'],
-            [Token::OpenBracket, '['],
-            [Token::CloseBracket, ']'],
-            [Token::OpenAngle, '<'],
-            [Token::CloseAngle, '>'],
-            [Token::LessThanEquals, '<='],
-            [Token::GreaterThanEquals, '>='],
-            [Token::Pipe, '|'],
-            [Token::Comma, ','],
-            [Token::Colon, ':'],
-        ];
-        foreach ($tokenCases as [$token, $expected]) {
-            yield $token->name => [$token, $expected];
+        // Every case, taken from the enum rather than listed here: a hand-written list is a copy of the enum that only
+        // ever tests itself, and goes stale the moment a token is added—as it had, by ten cases. What is pinned is
+        // that a token prints as its own backing value, for all of them and with no exception anywhere in the enum,
+        // which is the whole of Token::print()'s first arm. It says nothing about what those backing values actually
+        // are—that a token spells a particular piece of the language's syntax—which
+        // {@see self::testEveryTokenIsSpelledAsDeclared()} pins instead, independently of the enum.
+        foreach (Token::cases() as $token) {
+            yield $token->name => [$token, $token->value];
         }
         yield 'identifier' => ['foo', 'foo'];
         yield 'String literal' => [new Literal('foo'), '"foo"'];
         yield 'Int literal' => [new Literal(42), '42'];
         yield 'Float literal' => [new Literal(42.23), '42.23'];
+    }
+
+    /**
+     * The language's own operator and punctuation spellings, listed by hand. {@see self::printCases()} derives its
+     * expectation from the enum, so it can only ever pin that print() is faithful to whatever a token's backing value
+     * says—never what that value actually is. A typo here, such as `case NotEquals = '!=='` becoming `'!='`, would
+     * otherwise be caught only indirectly, by parser tests, and the failure would point at the parser rather than at
+     * the token that caused it. {@see self::testEveryTokenIsSpelledAsDeclared()} keeps this table from going stale
+     * the way the hand-written list {@see self::printCases()} replaced did—a token missing from it, an extra entry
+     * for one that no longer exists, and a wrong spelling all show up as one `assertSame` diff naming the token.
+     *
+     * @return array<string, string>
+     */
+    private static function spellings(): array
+    {
+        return [
+            'Dot' => '.',
+            'TripleEquals' => '===',
+            'NotEquals' => '!==',
+            'Not' => '!',
+            'Quote' => '"',
+            'OpenParen' => '(',
+            'CloseParen' => ')',
+            'OpenBracket' => '[',
+            'CloseBracket' => ']',
+            'OpenAngle' => '<',
+            'CloseAngle' => '>',
+            'LessThanEquals' => '<=',
+            'GreaterThanEquals' => '>=',
+            'OpenBrace' => '{',
+            'CloseBrace' => '}',
+            'Or' => '||',
+            'And' => '&&',
+            'Pipe' => '|',
+            'Comma' => ',',
+            'Colon' => ':',
+            'Minus' => '-',
+            'Plus' => '+',
+            'Asterisk' => '*',
+            'Slash' => '/',
+            'Percent' => '%',
+            'Arrow' => '->',
+        ];
     }
 
     /**
@@ -49,5 +81,19 @@ final class TokenTest extends TestCase
     public function testPrint(Token|string|Literal $token, string $expected): void
     {
         self::assertSame($expected, Token::print($token));
+    }
+
+    /**
+     * One fact, pinned once: every token's backing value is the spelling {@see self::spellings()} says. A missing
+     * entry, a stale one, a wrong spelling, or the two lists disagreeing in order all fail this one `assertSame`,
+     * with a diff that names the token that drifted.
+     */
+    public function testEveryTokenIsSpelledAsDeclared(): void
+    {
+        $actual = [];
+        foreach (Token::cases() as $token) {
+            $actual[$token->name] = $token->value;
+        }
+        self::assertSame(self::spellings(), $actual);
     }
 }

--- a/tests/unit/cases/not/call-result.txt
+++ b/tests/unit/cases/not/call-result.txt
@@ -1,0 +1,5 @@
+!haystack:list<string>.contains:bool(needle:string)
+-- Input --
+{ haystack: ["foo", "bar"], needle: "baz" }
+-- Output --
+true

--- a/tests/unit/cases/not/double-negation.txt
+++ b/tests/unit/cases/not/double-negation.txt
@@ -1,0 +1,5 @@
+!!a:bool
+-- Input --
+{ a: true }
+-- Output --
+true

--- a/tests/unit/cases/not/false-is-true.txt
+++ b/tests/unit/cases/not/false-is-true.txt
@@ -1,0 +1,5 @@
+!a:bool
+-- Input --
+{ a: false }
+-- Output --
+true

--- a/tests/unit/cases/not/true-is-false.txt
+++ b/tests/unit/cases/not/true-is-false.txt
@@ -1,0 +1,5 @@
+!a:bool
+-- Input --
+{ a: true }
+-- Output --
+false

--- a/tests/unit/cases/parentheses/not-groups-or.txt
+++ b/tests/unit/cases/parentheses/not-groups-or.txt
@@ -1,0 +1,5 @@
+!(a:bool || b:bool)
+-- Input --
+{ a: false, b: true }
+-- Output --
+false

--- a/tests/unit/cases/precedence/not-before-and.txt
+++ b/tests/unit/cases/precedence/not-before-and.txt
@@ -1,0 +1,5 @@
+!a:bool && b:bool
+-- Input --
+{ a: true, b: false }
+-- Output --
+false


### PR DESCRIPTION
Split from #82. The last of the four; #84, #85 and #86 are merged.

`!foo:bool` negates a boolean. It sits at the unary level, alongside `-`, so it binds tighter than every binary operator and looser than a postfix call: `!a:bool && b:bool` negates `a` alone, and `!xs:list<bool>.contains:bool(x)` negates what the call returns. `parseUnary()` already read its operand at its own level, so `!!a:bool` needs nothing extra.

The lexer gains `Token::Not`. `!` was previously only ever the first character of `!==`, and committed to it on sight; now it commits only after peeking the `=`, and is a token of its own otherwise. A stray `!` therefore reports where it sits rather than how far `!==` got.

`Expr::not()` folds nothing, unlike `Expr::negative()`: the language spells negative numbers, so a negated number literal has a literal to fold into, but `false` is not another spelling of `!true`. Its operand check is the one `&&` and `||` already made, with the wording pulled into one place so the three can't drift apart — and, since `!` has a single operand, with no side to name.

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hPJFKAuT6KvwTfBMMagQ4