### PR TITLE
Remove `Type::some()` — an identity function masquerading as a type constructor

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -213,11 +213,6 @@ final class Type implements Stringable
         return new self(new ApplicationShape(TypeConstructor::Option->value, [$some]));
     }
 
-    public static function some(self $some): self
-    {
-        return $some;
-    }
-
     public static function none(): self
     {
         return new self(new ApplicationShape(TypeConstructor::None->value));

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -162,17 +162,6 @@ final class TypeTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{Type | callable(): Type, Type | callable(): Type}>
-     */
-    public static function equalsCases(): iterable
-    {
-        yield 'Some<T> == T' => [
-            static fn() => Type::some(Type::string()),
-            Type::string(),
-        ];
-    }
-
-    /**
      * @return iterable<string, array{Type, string}>
      */
     public static function toStringCases(): iterable
@@ -711,20 +700,6 @@ final class TypeTest extends TestCase
     {
         self::assertFalse($a->equals($b));
         self::assertFalse($b->equals($a));
-    }
-
-    /**
-     * @param Type | callable(): Type $a
-     * @param Type | callable(): Type $b
-     */
-    #[DataProvider('equalsCases')]
-    public function testEquals(Type|callable $a, Type|callable $b): void
-    {
-        $a = $a instanceof Type ? $a : $a();
-        $b = $b instanceof Type ? $b : $b();
-
-        self::assertTrue($a->equals($b));
-        self::assertTrue($b->equals($a));
     }
 
     #[DataProvider('toStringCases')]


### PR DESCRIPTION
## Problem

`Type::some()` was a public static factory that returned its argument unchanged:

```php
public static function some(self $some): self
{
    return $some;
}
```

Sitting next to `option()` (a real `Option<T>` wrapper) and `none()` (a real `None` type), it read as "the Some branch of an Option" but constructed no `Some` type at all. `Type::some(Type::int())` was exactly `Type::int()`, so calls like `x.isSubtypeOf(Type::some(...))` behaved nothing like they read — a silent footgun. `Some` appears nowhere in the README's user-facing type list.

## Change

- Removed `Type::some()` from the public surface.
- Removed its only test. The `equalsCases` provider held a single case, `'Some<T> == T'`, whose whole purpose was to assert the identity behavior being removed; with it gone the provider would be empty, so the provider and its `testEquals` consumer go together. `equals()`'s positive path stays covered by `testAliasTypeEqualsAliasTarget`, and the `Some<...>` type-parsing path (`notEqualsCases`) is untouched.

### Deliberately left alone

`TypeConstructor::Some` and the parser's `resolveSome()` are legitimate — they back the `Some<T>` type syntax that `Option<T>` builds on. This PR targets only the misleading public factory.

## BC impact

Structural break (public method removal). Scoped for the **0.3.0 breaking release**.

## Verification

- PHPUnit: 1130 tests OK
- Psalm / PHPStan: no errors · PHP-CS-Fixer: clean · `composer check-deps`: no unknown symbols
- Infection on the diff (vs `master`, 100% MSI): deletion-only change, no mutants generated — passes under `--ignore-msi-with-no-mutations`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)