### PR TITLE
Mark internal-only plumbing `@internal`: ParsedToken, TypeHint, LocationTrait

### DIFF
--- a/src/LocationTrait.php
+++ b/src/LocationTrait.php
@@ -6,6 +6,10 @@ namespace Eventjet\Ausdruck;
 
 use Eventjet\Ausdruck\Parser\Span;
 
+/**
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
 trait LocationTrait
 {
     private readonly Span $location;

--- a/src/Parser/ParsedToken.php
+++ b/src/Parser/ParsedToken.php
@@ -7,6 +7,10 @@ namespace Eventjet\Ausdruck\Parser;
 use function assert;
 use function strlen;
 
+/**
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
 final class ParsedToken
 {
     /**

--- a/src/Parser/TypeHint.php
+++ b/src/Parser/TypeHint.php
@@ -10,6 +10,10 @@ use Stringable;
 
 use function sprintf;
 
+/**
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
 final class TypeHint implements Stringable
 {
     public function __construct(public readonly Type $type, public readonly bool $explicit)


### PR DESCRIPTION
Closes #94. Scoped for the **0.3.0 breaking release**.

## Problem

Three symbols are pure internal plumbing but carried **no `@internal`/`@psalm-internal`**, so under our own policy (public API = every `public` symbol not marked `@internal`) they were promised API by accident:

- `src/Parser/ParsedToken.php` — tokenizer output, produced by `Tokenizer`, consumed only by `@internal` parser internals. The one signature that names it (`ExpressionParser::__construct`) is `private`.
- `src/Parser/TypeHint.php` — referenced only by `Expr::get()`/`Get` (both `@internal`) and the private `ExpressionParser::variable()`.
- `src/LocationTrait.php` — an implementation-sharing trait mixed into `@internal` nodes.

None appear in the README or in any truly-public signature.

## Change

Mark all three `@internal` + `@psalm-internal Eventjet\Ausdruck` (the pairing our `InternalAnnotationConsistencyTest` requires, and the dominant scope convention in `src/Parser/`). The broad scope still permits the legitimate in-namespace consumers in `Eventjet\Ausdruck\Parser`.

Marking `LocationTrait` does **not** remove the public `location()` method from the published `UnaryOperator`/`Negative` hierarchy — that surface is handled separately in the hierarchy-sealing tickets.

## BC impact

Structural break (removing symbols from the public API). Can only land in the breaking minor. Low real-world blast radius — none of these can be legitimately named by a consumer today.

## Verification

`psalm`, `phpstan`, `phpunit` (1131 tests incl. `InternalAnnotationConsistencyTest`), and `php-cs-fixer` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)