### PR TITLE
Seal the UnaryOperator/Negative hierarchy (@internal + finalize)

### DIFF
--- a/src/Negative.php
+++ b/src/Negative.php
@@ -9,6 +9,9 @@ use Override;
 
 /**
  * Never wraps a {@see Literal}: {@see Expr::negative()} folds a negated number literal into a negative one.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
  */
 final class Negative extends UnaryOperator
 {

--- a/src/UnaryOperator.php
+++ b/src/UnaryOperator.php
@@ -17,25 +17,13 @@ use Override;
  * The one thing a unary operator has to carry that a binary one doesn't is its location: the operator stands to the
  * left of its only operand, so the node's span can't be derived from its subtree the way a binary operator's is.
  *
- * Unlike {@see BinaryOperator}, this class carries no `@internal`: {@see Negative} published it by omission, before
- * there was a base class to lift it into, so every member declared here—inherited by `Negative` and any other
- * subclass—is public API of a published class. Psalm resolves internality from the declaring class, not the
- * subclass, so annotating the base would silently take that API away without either tool or docblock saying so.
- * That is a real constraint on what may live here, not a fact to note in passing:
+ * {@see self::token()} is `protected`, unlike the public {@see BinaryOperator::token()}: {@see Precedence::unary()}
+ * takes the token and the operand rather than the node, so nothing outside this namespace needs it. Making it public
+ * would not open the hierarchy to outside subclasses anyway: it returns {@see Token}, which is itself `@internal`, so
+ * nothing outside this namespace can implement the abstract method regardless of its visibility.
  *
- * - The operand lives in a property called $expression, though every docblock here calls it the operand: `Negative`
- *   published that name first, so it is fixed.
- * - {@see self::__toString()} and {@see self::equals()} are not `final`, unlike their {@see BinaryOperator}
- *   counterparts: `Negative` published both before there was a base class to move them to, and neither can become
- *   final without risking a consumer's override.
- * - {@see self::token()} is `protected`, unlike the public {@see BinaryOperator::token()}: `Negative` never
- *   published it, so nothing forces it public, and {@see Precedence::unary()} takes the token and the operand
- *   instead of the node for exactly that reason. Being public would not have opened the hierarchy to outside
- *   subclasses anyway: {@see self::token()} returns {@see Token}, which is itself `@internal`, so nothing outside
- *   this namespace can implement the abstract method regardless of its visibility.
- *
- * Marking the hierarchy `@internal`, which would let all three become the {@see BinaryOperator} shape, is a backward
- * compatibility break and waits for the next major; tracked as eventjet/ausdruck#83.
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
  */
 abstract class UnaryOperator extends Expression
 {
@@ -46,7 +34,7 @@ abstract class UnaryOperator extends Expression
         $this->location = $location;
     }
 
-    public function __toString(): string
+    final public function __toString(): string
     {
         return Precedence::unary($this->token(), $this->expression);
     }
@@ -55,7 +43,7 @@ abstract class UnaryOperator extends Expression
      * Two operator nodes are the same expression when they are the same operator over an equal operand.
      */
     #[Override]
-    public function equals(Expression $other): bool
+    final public function equals(Expression $other): bool
     {
         return $other instanceof static
             && $this->expression->equals($other->expression);


### PR DESCRIPTION
Closes #95.

Scoped for the **0.3.0 breaking release**.

## What changed

**`src/UnaryOperator.php`**
- Added `@internal` + `@psalm-internal Eventjet\Ausdruck`, taking the base off the promised surface.
- Finalized `__toString()` and `equals()` to match the already-sealed `BinaryOperator`.
- Rewrote the docblock: dropped the section explaining why the class *couldn't* be internal (the `$expression`-name-is-fixed and methods-can't-be-final constraints) and the dangling `#83` / "next major" deferral. Kept the still-true `token()`-is-protected rationale.

**`src/Negative.php`**
- Added `@internal` + `@psalm-internal Eventjet\Ausdruck`.

`Not` was already born `@internal`, so the hierarchy is now sealed consistently with `BinaryOperator`.

## Why now, not "next major"

The old docblock deferred sealing to a literal 1.0 and pointed at a **dangling** `eventjet/ausdruck#83` (no such issue/PR exists). Per `docs/BACKWARD-COMPATIBILITY.md`, on the `0.x` line the **minor is the compatibility boundary** — 0.3.0 is the breaking window, so this belongs here rather than waiting years for 1.0.

## BC impact

Structural break: removes `Negative`/`UnaryOperator` and their inherited members from the public API and finalizes previously-published methods. This is the "finalizing a published method breaks BC even on a final class" case and can only land in a breaking minor. Roave's BC checker will (correctly) flag it.

## Verification

- `cs-check`, `psalm`, `phpstan`, `phpunit` (1131 tests) — all green.
- `infection-diff` — 0 mutations on the changed lines (docblock + `final` keywords carry no mutable logic), passes with `--ignore-msi-with-no-mutations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Aqoim7pUMKSoPCe4i9h9F