### PR TITLE
Seal the AbstractLiteral/ListLiteral hierarchy (@internal) (#96)

### DIFF
--- a/src/AbstractLiteral.php
+++ b/src/AbstractLiteral.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Eventjet\Ausdruck;
 
+/**
+ * The base for literal nodes — expressions whose value is known without a scope. The {@see self::value()} extension
+ * point exists only so a literal can materialize itself and its nested literals ({@see ListLiteral}, {@see StructLiteral})
+ * without going through {@see Expression::evaluate()}; the three subclasses that need it all live in this package, so
+ * nothing outside it has reason to add a fourth.
+ *
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
 abstract class AbstractLiteral extends Expression
 {
     abstract public function value(): mixed;

--- a/src/ListLiteral.php
+++ b/src/ListLiteral.php
@@ -12,6 +12,10 @@ use function array_map;
 use function implode;
 use function sprintf;
 
+/**
+ * @internal
+ * @psalm-internal Eventjet\Ausdruck
+ */
 final class ListLiteral extends AbstractLiteral
 {
     /**


### PR DESCRIPTION
Closes #96.

## What

Mark `AbstractLiteral` and `ListLiteral` `@internal` + `@psalm-internal Eventjet\Ausdruck` — they move as a pair. `ListLiteral` was the last published leaf pinning the abstract base open, and `AbstractLiteral::value()` was an accidental public extension point.

This brings the literal nodes in line with their already-`@internal` siblings `Literal` and `StructLiteral`. All three AST base hierarchies — `BinaryOperator`, `UnaryOperator` (#95), and `AbstractLiteral` — are now uniformly sealed, leaving `Expression` as the one intentional `@api` extension point.

`AbstractLiteral` also gains a short docblock (in the `BinaryOperator` style) explaining why `value()` exists and why no external subclass is warranted.

## BC impact

Structural break — removes `ListLiteral` and `AbstractLiteral::value()` from the public surface. Scoped to the **0.3.0 breaking release**; shares the same policy ruling as #95.

## Verification

`cs-check`, `psalm`, `phpstan`, and `phpunit` (1130 tests) all pass. `infection-diff` generated 0 mutations (comment-only lines), accepted by the `--ignore-msi-with-no-mutations` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyo7ZrxfsGywwmBJgWmoSm