### PR TITLE
Finalize Expression's concrete builder combinators (keep the class extendable)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -86,6 +86,16 @@ $params = $type->asFunction()?->argumentTypes();     // list<Type>
 - `Parser\Delimiters` is removed. It was an internal token detail with no role in the
   public API.
 
+#### `Expression`'s builder combinators are now `final`
+
+`Expression` stays an open extension point: subclass it and implement `location()`,
+`evaluate()`, `equals()`, and `getType()` to add a node, exactly as before. What changed is
+that its concrete builder combinators — `eq`, `neq`, `add`, `subtract`, `multiply`,
+`divide`, `modulo`, `gt`, `lt`, `gte`, `lte`, `or_`, `and_`, `not`, `call`, `matchesType`,
+and `isSubtypeOf` — are now `final`. They are fixed algorithms that assemble the internal
+node set, so a subclass has no reason to override them. If you did override one, move that
+logic out of the subclass; nothing else needs to change.
+
 #### Rendered form of some expressions and types changed
 
 Printing follows precedence, so an expression that mixes `&&` and `||` may render with

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -13,27 +13,27 @@ use Stringable;
  */
 abstract class Expression implements Stringable
 {
-    public function eq(self $other): Eq
+    final public function eq(self $other): Eq
     {
         return Expr::eq($this, $other);
     }
 
-    public function neq(self $other): self
+    final public function neq(self $other): self
     {
         return Expr::neq($this, $other);
     }
 
-    public function subtract(self $subtrahend): Subtract
+    final public function subtract(self $subtrahend): Subtract
     {
         return Expr::subtract($this, $subtrahend);
     }
 
-    public function add(self $addend): Add
+    final public function add(self $addend): Add
     {
         return Expr::add($this, $addend);
     }
 
-    public function multiply(self $multiplier): Multiply
+    final public function multiply(self $multiplier): Multiply
     {
         return Expr::multiply($this, $multiplier);
     }
@@ -41,7 +41,7 @@ abstract class Expression implements Stringable
     /**
      * The quotient is an option of the operands' type: none when the divisor evaluates to zero. See {@see Divide}.
      */
-    public function divide(self $divisor): Divide
+    final public function divide(self $divisor): Divide
     {
         return Expr::divide($this, $divisor);
     }
@@ -49,37 +49,37 @@ abstract class Expression implements Stringable
     /**
      * The remainder is an option of the operands' type: none when the divisor evaluates to zero. See {@see Modulo}.
      */
-    public function modulo(self $divisor): Modulo
+    final public function modulo(self $divisor): Modulo
     {
         return Expr::modulo($this, $divisor);
     }
 
-    public function gt(self $right): Gt
+    final public function gt(self $right): Gt
     {
         return Expr::gt($this, $right);
     }
 
-    public function lt(self $right): self
+    final public function lt(self $right): self
     {
         return Expr::lt($this, $right);
     }
 
-    public function gte(self $right): self
+    final public function gte(self $right): self
     {
         return Expr::gte($this, $right);
     }
 
-    public function lte(self $right): self
+    final public function lte(self $right): self
     {
         return Expr::lte($this, $right);
     }
 
-    public function or_(self $other): Or_
+    final public function or_(self $other): Or_
     {
         return Expr::or_($this, $other);
     }
 
-    public function and_(self $other): self
+    final public function and_(self $other): self
     {
         return Expr::and_($this, $other);
     }
@@ -89,7 +89,7 @@ abstract class Expression implements Stringable
      * its return type. Returning self is the shape every builder here is headed for, not a rule this one is the
      * exception to.
      */
-    public function not(): self
+    final public function not(): self
     {
         return Expr::not($this);
     }
@@ -103,7 +103,7 @@ abstract class Expression implements Stringable
      * @param Type $type The function's return type. There's no declaration here to contradict, so it's taken as given.
      * @param list<Expression> $arguments
      */
-    public function call(string $name, Type $type, array $arguments, Span|null $location = null): Call
+    final public function call(string $name, Type $type, array $arguments, Span|null $location = null): Call
     {
         return Expr::call(
             $this,
@@ -115,12 +115,12 @@ abstract class Expression implements Stringable
         );
     }
 
-    public function matchesType(Type $type): bool
+    final public function matchesType(Type $type): bool
     {
         return $this->getType()->equals($type);
     }
 
-    public function isSubtypeOf(Type $type): bool
+    final public function isSubtypeOf(Type $type): bool
     {
         return $this->getType()->isSubtypeOf($type);
     }

--- a/tests/unit/ExpressionFinalizationTest.php
+++ b/tests/unit/ExpressionFinalizationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\Ausdruck\Test\Unit;
+
+use Eventjet\Ausdruck\Expression;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function sprintf;
+
+/**
+ * Guards the shape of {@see Expression} as an extension point: the class stays open and its four extension-point
+ * methods stay overridable, but the concrete builder combinators are locked. A subclass adds a node by implementing
+ * the abstract methods; it has no legitimate reason to reimplement a combinator, which is a fixed algorithm over the
+ * closed, internal node set.
+ */
+final class ExpressionFinalizationTest extends TestCase
+{
+    private const CONCRETE_COMBINATORS = [
+        'eq',
+        'neq',
+        'subtract',
+        'add',
+        'multiply',
+        'divide',
+        'modulo',
+        'gt',
+        'lt',
+        'gte',
+        'lte',
+        'or_',
+        'and_',
+        'not',
+        'call',
+        'matchesType',
+        'isSubtypeOf',
+    ];
+    private const EXTENSION_POINTS = [
+        'location',
+        'evaluate',
+        'equals',
+        'getType',
+    ];
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function concreteCombinatorProvider(): iterable
+    {
+        foreach (self::CONCRETE_COMBINATORS as $method) {
+            yield $method => [$method];
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function extensionPointProvider(): iterable
+    {
+        foreach (self::EXTENSION_POINTS as $method) {
+            yield $method => [$method];
+        }
+    }
+
+    public function testTheClassStaysExtendable(): void
+    {
+        $class = new ReflectionClass(Expression::class);
+
+        self::assertFalse($class->isFinal(), 'Expression must stay open as an extension point.');
+        self::assertTrue(
+            $class->isAbstract(),
+            'Expression is an abstract base with methods for a subclass to implement.',
+        );
+    }
+
+    #[DataProvider('concreteCombinatorProvider')]
+    public function testConcreteCombinatorsAreFinal(string $method): void
+    {
+        self::assertTrue(
+            (new ReflectionClass(Expression::class))->getMethod($method)->isFinal(),
+            sprintf('Expression::%s() is a fixed algorithm and must be final.', $method),
+        );
+    }
+
+    #[DataProvider('extensionPointProvider')]
+    public function testExtensionPointsStayOverridable(string $method): void
+    {
+        $reflection = (new ReflectionClass(Expression::class))->getMethod($method);
+
+        self::assertTrue(
+            $reflection->isAbstract(),
+            sprintf('Expression::%s() is an extension point a subclass implements; it must stay abstract.', $method),
+        );
+        self::assertFalse(
+            $reflection->isFinal(),
+            sprintf('Expression::%s() must stay overridable.', $method),
+        );
+    }
+}


### PR DESCRIPTION
Closes #97. Scoped for the **0.3.0 breaking release**.

## What

Finalize the 17 concrete builder combinators on `Expression` — `eq`, `neq`, `add`, `subtract`, `multiply`, `divide`, `modulo`, `gt`, `lt`, `gte`, `lte`, `or_`, `and_`, `not`, `call`, `matchesType`, `isSubtypeOf`. These are fixed algorithms that assemble the closed, `@internal`-constructed node set, so a subclass has no legitimate reason to override them.

The class stays `abstract` (not `final`) and its four extension-point methods — `location`, `evaluate`, `equals`, `getType` — stay abstract and overridable. Subclassing `Expression` to add a custom node still works exactly as before; only the combinators are locked.

Return types are left untouched — narrowing them to `self` and collapsing `Eq`/`Gt` is the separate #92.

## Changes

- **`src/Expression.php`** — `final` on the 17 concrete combinators.
- **`tests/unit/ExpressionFinalizationTest.php`** (new) — reflection guard test matching the repo's structural-invariant style (see `InternalAnnotationConsistencyTest`): asserts the class stays open/abstract, every combinator is `final`, and each extension point stays abstract and overridable.
- **`UPGRADING.md`** — API-changes note documenting the structural break.

## BC impact

Structural break: finalizing previously-published methods. Correct for a `0.MINOR` bump; the Roave checker will flag it as expected (it can't run in a worktree, so it isn't run here).

## Verification

- `phpunit` — 1152 tests pass (22 new)
- `psalm`, `phpstan` — no errors
- `php-cs-fixer`, `composer-require-checker` — clean
- `infection-diff` (CI's 100% MSI gate on changed lines) — 16/16 mutations killed, Covered MSI 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)