### PR TITLE
Finalize the 0.3.0 CHANGELOG entry for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ changes; see [UPGRADING.md](UPGRADING.md) for the migration steps behind each on
 This changelog begins at 0.3.0. Earlier releases are recorded in the
 [git tags](https://github.com/eventjet/ausdruck/tags).
 
-## [0.3.0] - Unreleased
+## [Unreleased]
+
+## [0.3.0] - 2026-07-24
 
 A breaking release that rounds out the operator set and the type system. Most 0.2
 expressions and integrations keep working unchanged; the migration notes for the
@@ -70,4 +72,5 @@ cases that don't are in [UPGRADING.md](UPGRADING.md).
 - The `Eq` and `Gt` node classes — the `@internal` concrete nodes that `eq()` and `gt()`
   returned in 0.2; now that those builders return `self`, they fold into `Comparison`.
 
-[0.3.0]: https://github.com/eventjet/ausdruck/compare/0.2.4...HEAD
+[Unreleased]: https://github.com/eventjet/ausdruck/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/eventjet/ausdruck/compare/0.2.4...0.3.0


### PR DESCRIPTION
Prepares the 0.3.0 release by finalizing the CHANGELOG. No code or behavior changes.

- Date the `[0.3.0]` heading (was `Unreleased`).
- Repoint its compare link at `0.2.4...0.3.0` (was `...HEAD`).
- Add a fresh `[Unreleased]` section tracking `0.3.0...HEAD`.

After this merges, tag `0.3.0` on master to cut the release (Packagist derives the version from the tag).

The 0.3.0 scope is otherwise final: `composer check` passes on master (100% MSI), and the two open issues (#47, #59) are deliberately out of scope — #47's own analysis defers parse-time unknown-function rejection past generics to a major version / opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JddJCEqvyLKoDgx6oxYVym